### PR TITLE
fix: address PR #13 Copilot review feedback

### DIFF
--- a/server/internal/api/handlers/designs.go
+++ b/server/internal/api/handlers/designs.go
@@ -38,6 +38,8 @@ type createDesignRequest struct {
 
 // Create handles POST /api/designs.
 func (h *DesignHandler) Create(w http.ResponseWriter, r *http.Request) {
+	// Limit request body to 1 MB to guard against large-payload DoS attacks.
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var req createDesignRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")

--- a/server/internal/service/design_service.go
+++ b/server/internal/service/design_service.go
@@ -4,6 +4,7 @@ package service
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/rnwolfe/fabrik/server/internal/models"
 )
@@ -28,6 +29,8 @@ func NewDesignService(repo DesignRepository) *DesignService {
 
 // CreateDesign validates and creates a new Design.
 func (s *DesignService) CreateDesign(name, description string) (*models.Design, error) {
+	// Trim whitespace so that names like "   " are rejected alongside "".
+	name = strings.TrimSpace(name)
 	if name == "" {
 		return nil, fmt.Errorf("%w: design name is required", models.ErrConstraintViolation)
 	}

--- a/server/internal/store/db.go
+++ b/server/internal/store/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/sqlite"
@@ -16,8 +17,19 @@ import (
 // Open opens (or creates) the SQLite database at path, enables WAL mode and
 // foreign key enforcement, then runs all pending migrations from migrationsFS.
 // It returns the open *sql.DB ready for use.
+//
+// Foreign key enforcement is set via a DSN pragma so that every connection in
+// the pool has it enabled from the moment it is opened, rather than relying on
+// a single PRAGMA statement that is scoped to only the connection it runs on.
 func Open(path string, migrationsFS fs.FS) (*sql.DB, error) {
-	db, err := sql.Open("sqlite", path)
+	// Append _pragma=foreign_keys(1) to the DSN so modernc.org/sqlite enables
+	// foreign key enforcement on every new connection it opens.
+	sep := "&"
+	if !strings.Contains(path, "?") {
+		sep = "?"
+	}
+	dsn := path + sep + "_pragma=foreign_keys(1)"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite db: %w", err)
 	}
@@ -26,12 +38,6 @@ func Open(path string, migrationsFS fs.FS) (*sql.DB, error) {
 	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("enable WAL: %w", err)
-	}
-
-	// Enforce referential integrity.
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("enable foreign keys: %w", err)
 	}
 
 	if err := runMigrations(db, migrationsFS); err != nil {

--- a/server/internal/store/design_store_test.go
+++ b/server/internal/store/design_store_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -57,7 +58,7 @@ func TestDesignStore_CRUD(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for missing design")
 		}
-		if !isNotFound(err) {
+		if !errors.Is(err, models.ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got %v", err)
 		}
 	})
@@ -68,14 +69,14 @@ func TestDesignStore_CRUD(t *testing.T) {
 			t.Fatalf("Delete: %v", err)
 		}
 		_, err := s.Get(created.ID)
-		if !isNotFound(err) {
+		if !errors.Is(err, models.ErrNotFound) {
 			t.Errorf("expected ErrNotFound after delete, got %v", err)
 		}
 	})
 
 	t.Run("delete not found", func(t *testing.T) {
 		err := s.Delete(999999)
-		if !isNotFound(err) {
+		if !errors.Is(err, models.ErrNotFound) {
 			t.Errorf("expected ErrNotFound, got %v", err)
 		}
 	})
@@ -108,28 +109,4 @@ func TestDesignStore_ConcurrentReads(t *testing.T) {
 	for err := range errCh {
 		t.Errorf("concurrent read error: %v", err)
 	}
-}
-
-// isNotFound reports whether err wraps models.ErrNotFound.
-func isNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	return err.Error() == models.ErrNotFound.Error() ||
-		containsError(err, models.ErrNotFound)
-}
-
-func containsError(err, target error) bool {
-	for err != nil {
-		if err == target {
-			return true
-		}
-		type unwrapper interface{ Unwrap() error }
-		u, ok := err.(unwrapper)
-		if !ok {
-			return false
-		}
-		err = u.Unwrap()
-	}
-	return false
 }

--- a/server/internal/store/migration_test.go
+++ b/server/internal/store/migration_test.go
@@ -12,7 +12,8 @@ import (
 	"github.com/rnwolfe/fabrik/server/internal/migrations"
 )
 
-// newMigrator opens a fresh in-memory DB and returns a migrator plus a cleanup func.
+// newMigrator opens a fresh in-memory DB and returns a migrator and the underlying *sql.DB.
+// The DB is automatically closed via t.Cleanup when the test finishes.
 func newMigrator(t *testing.T) (*migrate.Migrate, *sql.DB) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Follow-up fixes for the Copilot review comments left on PR #13 (domain model, database schema, and Design CRUD API).

## Changes

1. **`server/internal/store/db.go`** — Replace the connection-scoped `PRAGMA foreign_keys=ON` exec with a DSN pragma (`?_pragma=foreign_keys(1)`) so that every connection the pool opens has FK enforcement enabled, not just the first one.

2. **`server/internal/api/handlers/designs.go`** — Wrap `r.Body` with `http.MaxBytesReader(w, r.Body, 1<<20)` (1 MB) before `json.NewDecoder` in the `Create` handler to guard against large-payload DoS attacks.

3. **`server/internal/service/design_service.go`** — Call `strings.TrimSpace(name)` before the empty-string check in `CreateDesign` so whitespace-only names (e.g. `"   "`) are rejected and the trimmed value is stored.

4. **`server/internal/store/design_store_test.go`** — Remove the brittle `isNotFound` / `containsError` string-matching helpers; replace all call sites with `errors.Is(err, models.ErrNotFound)`.

5. **`server/internal/store/migration_test.go`** — Fix the misleading `newMigrator` comment that said it returns "a migrator plus a cleanup func" — it actually returns `(*migrate.Migrate, *sql.DB)` with cleanup registered via `t.Cleanup`.

## Test plan

- [x] `cd server && go test ./...` — all 40 tests pass
- [x] `cd server && go vet ./...` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)