### PR TITLE
feat: rack modeling with constraint validation

### DIFF
--- a/docs/knowledge/infrastructure/rack-modeling.md
+++ b/docs/knowledge/infrastructure/rack-modeling.md
@@ -1,0 +1,131 @@
+---
+title: Rack Modeling
+category: infrastructure
+tags: [rack, physical, constraint, capacity, power, RU, placement]
+---
+
+# Rack Modeling
+
+fabrik's rack modeling feature lets you define rack templates, create rack instances, assign devices to specific RU positions, and automatically validate physical constraints — RU capacity and power budget — in real time.
+
+## Core Concepts
+
+### Rack Types (Templates)
+
+A **rack type** is a reusable template that captures the standard specifications for a rack model:
+
+- **Height (U)** — how many rack units the rack provides (e.g., 42U, 24U)
+- **Power Capacity (W)** — the total PDU power budget in watts
+
+When you create a rack from a rack type, the specs are copied into the rack instance. The rack can then diverge from the template (e.g., a custom power limit).
+
+### Rack Instances
+
+A **rack** is a physical installation. It may be:
+
+- **Standalone** — not assigned to a block
+- **Block-assigned** — placed in a logical Block within a Site hierarchy
+
+Each rack tracks:
+- Its inherited or custom height (U) and power capacity (W)
+- All devices currently installed (with their RU positions)
+- Real-time summary of used/available RU and power
+
+### RU Positions
+
+RU positions are **1-indexed from the bottom** of the rack. A 42U rack has positions 1–42. Multi-RU devices (e.g., a 7U chassis) occupy consecutive positions: a device at position 1 with height 7U occupies positions 1–7.
+
+## Constraint Validation
+
+### RU Capacity (Hard Limit)
+
+fabrik rejects any placement that would overflow the rack's RU capacity:
+
+- Device height_u > remaining available U → **400 Bad Request**
+- Requested position + device height − 1 > rack height → **400 Bad Request**
+- Position overlaps an existing device → **400 Bad Request**
+
+Positions must be ≥ 1. Position 0 and negative positions are rejected.
+
+### Power Budget (Soft Limit)
+
+Power is a **soft limit**: oversubscription is allowed, but warned:
+
+- Placing a device that would exceed the rack's power capacity → response includes a `warning` field
+- Rack summary marks a warning when utilization exceeds 80%
+
+This allows for planning headroom and accounting for redundant PSU configurations.
+
+## API Overview
+
+### Rack Types
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/rack-types` | Create a rack type |
+| `GET` | `/api/rack-types` | List all rack types |
+| `GET` | `/api/rack-types/:id` | Get a single rack type |
+| `PUT` | `/api/rack-types/:id` | Update a rack type |
+| `DELETE` | `/api/rack-types/:id` | Delete (409 if racks reference it) |
+
+### Racks
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/racks` | Create a rack (optionally from a type) |
+| `GET` | `/api/racks` | List racks (filter with `?block_id=`) |
+| `GET` | `/api/racks/:id` | Get rack with usage summary |
+| `PUT` | `/api/racks/:id` | Update name, description, block |
+| `DELETE` | `/api/racks/:id` | Delete rack (cascades to devices) |
+
+### Device Placement
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/racks/:id/devices` | Place device (auto-suggests position if omitted) |
+| `PUT` | `/api/racks/:rack_id/devices/:device_id` | Move device within the same rack |
+| `PUT` | `/api/racks/:rack_id/devices/:device_id/move` | Move device to a different rack |
+| `DELETE` | `/api/racks/:rack_id/devices/:device_id` | Remove device (`?compact=true` to shift others down) |
+
+## Rack Summary Response
+
+`GET /api/racks/:id` returns an enriched summary:
+
+```json
+{
+  "id": 1,
+  "name": "row-a-rack-01",
+  "height_u": 42,
+  "power_capacity_w": 10000,
+  "used_u": 8,
+  "available_u": 34,
+  "used_watts": 1800,
+  "warning": "power utilization at 82% (8200W / 10000W)",
+  "devices": [
+    {
+      "id": 5,
+      "name": "spine-01",
+      "position": 1,
+      "height_u": 2,
+      "power_watts": 900,
+      "model_vendor": "Arista",
+      "model_name": "7050TX-64",
+      "role": "spine"
+    }
+  ]
+}
+```
+
+## Device Removal: Compact Mode
+
+When removing a device, pass `?compact=true` to shift all devices above the removed device's slot downward, filling the gap. Use `?compact=false` (default) to leave the gap empty and preserve existing positions.
+
+## Cross-Rack Moves
+
+To move a device from one rack to another, `PUT /api/racks/:src_rack_id/devices/:device_id/move` with the body:
+
+```json
+{ "dest_rack_id": 2, "position": 5 }
+```
+
+The same constraint checks apply to the destination rack. If `position` is omitted (or 0), fabrik auto-suggests the lowest available slot.

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -28,6 +28,11 @@ export const routes: Routes = [
           ),
       },
       {
+        path: 'racks',
+        loadChildren: () =>
+          import('./features/racks/racks.routes').then(m => m.RACKS_ROUTES),
+      },
+      {
         path: 'metrics',
         loadChildren: () =>
           import('./features/metrics/metrics.routes').then(

--- a/frontend/src/app/core/shell/shell.component.ts
+++ b/frontend/src/app/core/shell/shell.component.ts
@@ -56,6 +56,7 @@ export class ShellComponent implements OnInit, OnDestroy {
     { label: 'Home', icon: 'home', route: '/' },
     { label: 'Design', icon: 'device_hub', route: '/design' },
     { label: 'Catalog', icon: 'inventory_2', route: '/catalog' },
+    { label: 'Racks', icon: 'dns', route: '/racks' },
     { label: 'Metrics', icon: 'bar_chart', route: '/metrics' },
     { label: 'Knowledge Base', icon: 'menu_book', route: '/knowledge' },
   ];

--- a/frontend/src/app/features/racks/components/rack-list/rack-list.component.spec.ts
+++ b/frontend/src/app/features/racks/components/rack-list/rack-list.component.spec.ts
@@ -1,0 +1,119 @@
+import { render, screen, fireEvent } from '@testing-library/angular';
+import { of, throwError } from 'rxjs';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { vi } from 'vitest';
+
+import { RackListComponent } from './rack-list.component';
+import { RackService } from '../../rack.service';
+import { Rack } from '../../../../models';
+
+const mockRacks: Rack[] = [
+  {
+    id: 1, name: 'rack-01', height_u: 42, power_capacity_w: 10000,
+    block_id: null, rack_type_id: null, description: '', created_at: '', updated_at: '',
+  },
+  {
+    id: 2, name: 'rack-02', height_u: 24, power_capacity_w: 5000,
+    block_id: 3, rack_type_id: 1, description: 'Edge rack', created_at: '', updated_at: '',
+  },
+];
+
+function makeService(racks: Rack[] = mockRacks) {
+  return {
+    listRacks: vi.fn(() => of(racks)),
+    deleteRack: vi.fn(() => of(undefined)),
+    createRack: vi.fn(() => of(racks[0])),
+  } as unknown as RackService;
+}
+
+async function renderComponent(service: RackService) {
+  return render(RackListComponent, {
+    providers: [
+      { provide: RackService, useValue: service },
+      provideAnimationsAsync(),
+    ],
+  });
+}
+
+describe('RackListComponent', () => {
+  it('should display rack names after load', async () => {
+    const svc = makeService();
+    await renderComponent(svc);
+    expect(screen.getByText('rack-01')).toBeTruthy();
+    expect(screen.getByText('rack-02')).toBeTruthy();
+  });
+
+  it('should display empty state when no racks', async () => {
+    const svc = makeService([]);
+    await renderComponent(svc);
+    expect(screen.getByText(/No racks yet/i)).toBeTruthy();
+  });
+
+  it('should show error message on load failure', async () => {
+    const svc = {
+      listRacks: vi.fn(() => throwError(() => new Error('network error'))),
+      deleteRack: vi.fn(() => of(undefined)),
+      createRack: vi.fn(() => of(mockRacks[0])),
+    } as unknown as RackService;
+    await renderComponent(svc);
+    expect(screen.getByRole('alert')).toBeTruthy();
+  });
+
+  it('should display rack height in U', async () => {
+    const svc = makeService();
+    await renderComponent(svc);
+    expect(screen.getByText(/42U/)).toBeTruthy();
+    expect(screen.getByText(/24U/)).toBeTruthy();
+  });
+
+  it('should display power capacity', async () => {
+    const svc = makeService();
+    await renderComponent(svc);
+    expect(screen.getByText(/10000W/)).toBeTruthy();
+  });
+
+  it('should call deleteRack when delete confirmed', async () => {
+    const svc = makeService();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    await renderComponent(svc);
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete rack/i });
+    fireEvent.click(deleteButtons[0]);
+
+    expect(svc.deleteRack).toHaveBeenCalledWith(1);
+    confirmSpy.mockRestore();
+  });
+
+  it('should not call deleteRack when confirmation declined', async () => {
+    const svc = makeService();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await renderComponent(svc);
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete rack/i });
+    fireEvent.click(deleteButtons[0]);
+
+    expect(svc.deleteRack).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('should render Add Rack button', async () => {
+    const svc = makeService();
+    await renderComponent(svc);
+    expect(screen.getByRole('button', { name: /create rack/i })).toBeTruthy();
+  });
+
+  it('should reload racks when retry clicked', async () => {
+    const svc = {
+      listRacks: vi.fn(() => throwError(() => new Error('network error'))),
+      deleteRack: vi.fn(() => of(undefined)),
+      createRack: vi.fn(() => of(mockRacks[0])),
+    } as unknown as RackService;
+    await renderComponent(svc);
+
+    (svc.listRacks as ReturnType<typeof vi.fn>).mockReturnValue(of(mockRacks));
+    const retryBtn = screen.getByRole('button', { name: /retry/i });
+    fireEvent.click(retryBtn);
+
+    expect(svc.listRacks).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/app/features/racks/components/rack-list/rack-list.component.ts
+++ b/frontend/src/app/features/racks/components/rack-list/rack-list.component.ts
@@ -1,0 +1,258 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatDialogModule } from '@angular/material/dialog';
+
+import { RackService } from '../../rack.service';
+import { Rack } from '../../../../models';
+
+/**
+ * RackListComponent displays all racks with their capacity summary
+ * and allows creating, navigating to, and deleting racks.
+ */
+@Component({
+  selector: 'app-rack-list',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatChipsModule,
+    MatTooltipModule,
+    MatSnackBarModule,
+    MatDialogModule,
+  ],
+  template: `
+    <div class="rack-list-page">
+      <header class="page-header">
+        <h1>Rack Management</h1>
+        <p class="subtitle">Plan and manage physical rack placements.</p>
+      </header>
+
+      <div class="toolbar">
+        <button mat-raised-button color="primary" (click)="createRack()" aria-label="Create rack">
+          <mat-icon>add</mat-icon>
+          Add Rack
+        </button>
+      </div>
+
+      @if (loading()) {
+        <div class="loading-center" role="status" aria-label="Loading racks">
+          <mat-spinner diameter="48"></mat-spinner>
+        </div>
+      } @else if (error()) {
+        <div class="error-banner" role="alert">
+          <mat-icon>error</mat-icon>
+          <span>{{ error() }}</span>
+          <button mat-button (click)="loadRacks()">Retry</button>
+        </div>
+      } @else if (racks().length === 0) {
+        <div class="empty-state" role="status">
+          <mat-icon class="empty-icon">dns</mat-icon>
+          <h2>No racks yet</h2>
+          <p>Create your first rack to start planning device placement.</p>
+          <button mat-raised-button color="primary" (click)="createRack()">Add Rack</button>
+        </div>
+      } @else {
+        <div class="rack-grid">
+          @for (rack of racks(); track rack.id) {
+            <mat-card class="rack-card" appearance="outlined">
+              <mat-card-header>
+                <mat-card-title>{{ rack.name }}</mat-card-title>
+                <mat-card-subtitle>
+                  {{ rack.height_u }}U &bull; {{ rack.power_capacity_w > 0 ? (rack.power_capacity_w + 'W') : 'No power limit' }}
+                </mat-card-subtitle>
+              </mat-card-header>
+
+              <mat-card-content>
+                @if (rack.description) {
+                  <p class="rack-description">{{ rack.description }}</p>
+                }
+                <div class="rack-meta">
+                  @if (rack.block_id) {
+                    <mat-chip>Block {{ rack.block_id }}</mat-chip>
+                  } @else {
+                    <mat-chip>Standalone</mat-chip>
+                  }
+                  @if (rack.rack_type_id) {
+                    <mat-chip>Type {{ rack.rack_type_id }}</mat-chip>
+                  }
+                </div>
+              </mat-card-content>
+
+              <mat-card-actions align="end">
+                <button
+                  mat-icon-button
+                  color="warn"
+                  [matTooltip]="'Delete rack'"
+                  aria-label="Delete rack"
+                  (click)="deleteRack(rack)"
+                >
+                  <mat-icon>delete</mat-icon>
+                </button>
+              </mat-card-actions>
+            </mat-card>
+          }
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .rack-list-page {
+      padding: 1.5rem;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    .page-header {
+      margin-bottom: 1.5rem;
+    }
+
+    .page-header h1 {
+      margin: 0 0 0.25rem;
+      font-size: 1.75rem;
+      font-weight: 500;
+    }
+
+    .subtitle {
+      margin: 0;
+      color: var(--mat-sys-on-surface-variant);
+    }
+
+    .toolbar {
+      margin-bottom: 1.5rem;
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .loading-center {
+      display: flex;
+      justify-content: center;
+      padding: 3rem;
+    }
+
+    .error-banner {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 1rem;
+      border-radius: 8px;
+      background: var(--mat-sys-error-container);
+      color: var(--mat-sys-on-error-container);
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 4rem 2rem;
+      color: var(--mat-sys-on-surface-variant);
+    }
+
+    .empty-icon {
+      font-size: 64px;
+      width: 64px;
+      height: 64px;
+      margin-bottom: 1rem;
+    }
+
+    .empty-state h2 {
+      margin: 0 0 0.5rem;
+      font-size: 1.25rem;
+    }
+
+    .empty-state p {
+      margin: 0 0 1.5rem;
+    }
+
+    .rack-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 1rem;
+    }
+
+    .rack-card {
+      transition: box-shadow 0.2s ease;
+    }
+
+    .rack-description {
+      font-size: 0.875rem;
+      color: var(--mat-sys-on-surface-variant);
+      margin-bottom: 0.75rem;
+    }
+
+    .rack-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+  `],
+})
+export class RackListComponent implements OnInit {
+  private readonly rackService = inject(RackService);
+  private readonly snackBar = inject(MatSnackBar);
+
+  readonly racks = signal<Rack[]>([]);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.loadRacks();
+  }
+
+  loadRacks(): void {
+    this.loading.set(true);
+    this.error.set(null);
+    this.rackService.listRacks().subscribe({
+      next: racks => {
+        this.racks.set(racks);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('Failed to load racks. Please try again.');
+        this.loading.set(false);
+      },
+    });
+  }
+
+  createRack(): void {
+    const name = window.prompt('Enter rack name:');
+    if (!name?.trim()) return;
+
+    const heightStr = window.prompt('Enter rack height in U (default: 42):', '42');
+    const heightU = Math.max(1, parseInt(heightStr ?? '42', 10) || 42);
+
+    const powerStr = window.prompt('Enter power capacity in Watts (0 for no limit):', '0');
+    const powerCapacityW = Math.max(0, parseInt(powerStr ?? '0', 10) || 0);
+
+    this.rackService.createRack({ name: name.trim(), height_u: heightU, power_capacity_w: powerCapacityW }).subscribe({
+      next: rack => {
+        this.racks.update(racks => [...racks, rack]);
+        this.snackBar.open(`Rack "${rack.name}" created`, 'Dismiss', { duration: 3000 });
+      },
+      error: () => {
+        this.snackBar.open('Failed to create rack', 'Dismiss', { duration: 3000 });
+      },
+    });
+  }
+
+  deleteRack(rack: Rack): void {
+    if (!window.confirm(`Delete rack "${rack.name}"? This will remove all devices in it.`)) return;
+
+    this.rackService.deleteRack(rack.id).subscribe({
+      next: () => {
+        this.racks.update(racks => racks.filter(r => r.id !== rack.id));
+        this.snackBar.open(`Rack "${rack.name}" deleted`, 'Dismiss', { duration: 3000 });
+      },
+      error: () => {
+        this.snackBar.open('Failed to delete rack', 'Dismiss', { duration: 3000 });
+      },
+    });
+  }
+}

--- a/frontend/src/app/features/racks/rack.service.spec.ts
+++ b/frontend/src/app/features/racks/rack.service.spec.ts
@@ -1,0 +1,216 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+
+import { RackService } from './rack.service';
+import { Rack, RackSummary, RackTemplate, PlaceDeviceResult } from '../../models';
+
+describe('RackService', () => {
+  let service: RackService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [RackService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(RackService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  describe('listRackTypes', () => {
+    it('should GET /api/rack-types', () => {
+      const mock: RackTemplate[] = [
+        { id: 1, name: '42U', height_u: 42, power_capacity_w: 10000, description: '', created_at: '', updated_at: '' },
+      ];
+      let result: RackTemplate[] | undefined;
+      service.listRackTypes().subscribe(rts => { result = rts; });
+      const req = httpMock.expectOne('/api/rack-types');
+      expect(req.request.method).toBe('GET');
+      req.flush(mock);
+      expect(result?.length).toBe(1);
+      expect(result?.[0].name).toBe('42U');
+    });
+  });
+
+  describe('createRackType', () => {
+    it('should POST /api/rack-types', () => {
+      const mock: RackTemplate = { id: 2, name: '24U', height_u: 24, power_capacity_w: 5000, description: '', created_at: '', updated_at: '' };
+      let result: RackTemplate | undefined;
+      service.createRackType({ name: '24U', height_u: 24, power_capacity_w: 5000 }).subscribe(rt => { result = rt; });
+      const req = httpMock.expectOne('/api/rack-types');
+      expect(req.request.method).toBe('POST');
+      req.flush(mock);
+      expect(result?.id).toBe(2);
+    });
+  });
+
+  describe('updateRackType', () => {
+    it('should PUT /api/rack-types/:id', () => {
+      const mock: RackTemplate = { id: 1, name: 'updated', height_u: 42, power_capacity_w: 10000, description: '', created_at: '', updated_at: '' };
+      let result: RackTemplate | undefined;
+      service.updateRackType(1, { name: 'updated', height_u: 42, power_capacity_w: 10000 }).subscribe(rt => { result = rt; });
+      const req = httpMock.expectOne('/api/rack-types/1');
+      expect(req.request.method).toBe('PUT');
+      req.flush(mock);
+      expect(result?.name).toBe('updated');
+    });
+  });
+
+  describe('deleteRackType', () => {
+    it('should DELETE /api/rack-types/:id', () => {
+      let called = false;
+      service.deleteRackType(1).subscribe(() => { called = true; });
+      const req = httpMock.expectOne('/api/rack-types/1');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null, { status: 204, statusText: 'No Content' });
+      expect(called).toBe(true);
+    });
+  });
+
+  describe('listRacks', () => {
+    it('should GET /api/racks', () => {
+      const mock: Rack[] = [
+        { id: 1, name: 'rack-01', height_u: 42, power_capacity_w: 5000, block_id: null, rack_type_id: null, description: '', created_at: '', updated_at: '' },
+      ];
+      let result: Rack[] | undefined;
+      service.listRacks().subscribe(racks => { result = racks; });
+      const req = httpMock.expectOne('/api/racks');
+      expect(req.request.method).toBe('GET');
+      req.flush(mock);
+      expect(result?.length).toBe(1);
+    });
+
+    it('should GET /api/racks?block_id=5 when blockId provided', () => {
+      service.listRacks(5).subscribe();
+      const req = httpMock.expectOne(r => r.url === '/api/racks' && r.params.get('block_id') === '5');
+      expect(req.request.method).toBe('GET');
+      req.flush([]);
+    });
+  });
+
+  describe('getRack', () => {
+    it('should GET /api/racks/:id with summary', () => {
+      const mock: RackSummary = {
+        id: 1, name: 'rack-01', height_u: 42, power_capacity_w: 5000, block_id: null, rack_type_id: null,
+        description: '', created_at: '', updated_at: '',
+        used_u: 2, available_u: 40, used_watts: 500, devices: [],
+      };
+      let result: RackSummary | undefined;
+      service.getRack(1).subscribe(summary => { result = summary; });
+      const req = httpMock.expectOne('/api/racks/1');
+      expect(req.request.method).toBe('GET');
+      req.flush(mock);
+      expect(result?.used_u).toBe(2);
+      expect(result?.available_u).toBe(40);
+    });
+  });
+
+  describe('createRack', () => {
+    it('should POST /api/racks', () => {
+      const mock: Rack = { id: 3, name: 'new-rack', height_u: 42, power_capacity_w: 0, block_id: null, rack_type_id: null, description: '', created_at: '', updated_at: '' };
+      let result: Rack | undefined;
+      service.createRack({ name: 'new-rack', height_u: 42 }).subscribe(r => { result = r; });
+      const req = httpMock.expectOne('/api/racks');
+      expect(req.request.method).toBe('POST');
+      req.flush(mock);
+      expect(result?.id).toBe(3);
+    });
+  });
+
+  describe('updateRack', () => {
+    it('should PUT /api/racks/:id', () => {
+      const mock: Rack = { id: 1, name: 'updated-rack', height_u: 42, power_capacity_w: 5000, block_id: null, rack_type_id: null, description: '', created_at: '', updated_at: '' };
+      let result: Rack | undefined;
+      service.updateRack(1, { name: 'updated-rack' }).subscribe(r => { result = r; });
+      const req = httpMock.expectOne('/api/racks/1');
+      expect(req.request.method).toBe('PUT');
+      req.flush(mock);
+      expect(result?.name).toBe('updated-rack');
+    });
+  });
+
+  describe('deleteRack', () => {
+    it('should DELETE /api/racks/:id', () => {
+      let called = false;
+      service.deleteRack(1).subscribe(() => { called = true; });
+      const req = httpMock.expectOne('/api/racks/1');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null, { status: 204, statusText: 'No Content' });
+      expect(called).toBe(true);
+    });
+  });
+
+  describe('placeDevice', () => {
+    it('should POST /api/racks/:id/devices', () => {
+      const mock: PlaceDeviceResult = {
+        device: { id: 1, rack_id: 1, device_model_id: 2, name: 'dev', role: 'leaf', position: 1, description: '', created_at: '', updated_at: '' },
+      };
+      let result: PlaceDeviceResult | undefined;
+      service.placeDevice(1, { device_model_id: 2, name: 'dev', position: 1 }).subscribe(r => { result = r; });
+      const req = httpMock.expectOne('/api/racks/1/devices');
+      expect(req.request.method).toBe('POST');
+      req.flush(mock);
+      expect(result?.device.id).toBe(1);
+    });
+
+    it('should include warning when power threshold exceeded', () => {
+      const mock: PlaceDeviceResult = {
+        device: { id: 1, rack_id: 1, device_model_id: 2, name: 'dev', role: 'leaf', position: 1, description: '', created_at: '', updated_at: '' },
+        warning: 'power utilization at 90% (900W / 1000W)',
+      };
+      let result: PlaceDeviceResult | undefined;
+      service.placeDevice(1, { device_model_id: 2, name: 'dev' }).subscribe(r => { result = r; });
+      const req = httpMock.expectOne('/api/racks/1/devices');
+      req.flush(mock);
+      expect(result?.warning).toBeDefined();
+      expect(result?.warning).toContain('power');
+    });
+  });
+
+  describe('removeDevice', () => {
+    it('should DELETE with compact=false by default', () => {
+      let called = false;
+      service.removeDevice(1, 5).subscribe(() => { called = true; });
+      const req = httpMock.expectOne(r => r.url === '/api/racks/1/devices/5' && r.params.get('compact') === 'false');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null, { status: 204, statusText: 'No Content' });
+      expect(called).toBe(true);
+    });
+
+    it('should pass compact=true when specified', () => {
+      service.removeDevice(1, 5, true).subscribe();
+      const req = httpMock.expectOne(r => r.url === '/api/racks/1/devices/5' && r.params.get('compact') === 'true');
+      req.flush(null, { status: 204, statusText: 'No Content' });
+    });
+  });
+
+  describe('moveDeviceInRack', () => {
+    it('should PUT /api/racks/:rackId/devices/:deviceId', () => {
+      const mock: PlaceDeviceResult = {
+        device: { id: 5, rack_id: 1, device_model_id: 1, name: 'dev', role: 'leaf', position: 5, description: '', created_at: '', updated_at: '' },
+      };
+      let result: PlaceDeviceResult | undefined;
+      service.moveDeviceInRack(1, 5, { position: 5 }).subscribe(r => { result = r; });
+      const req = httpMock.expectOne('/api/racks/1/devices/5');
+      expect(req.request.method).toBe('PUT');
+      req.flush(mock);
+      expect(result?.device.position).toBe(5);
+    });
+  });
+
+  describe('moveDeviceCrossRack', () => {
+    it('should PUT /api/racks/:rackId/devices/:deviceId/move', () => {
+      const mock: PlaceDeviceResult = {
+        device: { id: 5, rack_id: 2, device_model_id: 1, name: 'moved', role: 'spine', position: 3, description: '', created_at: '', updated_at: '' },
+      };
+      let result: PlaceDeviceResult | undefined;
+      service.moveDeviceCrossRack(1, 5, { dest_rack_id: 2, position: 3 }).subscribe(r => { result = r; });
+      const req = httpMock.expectOne('/api/racks/1/devices/5/move');
+      expect(req.request.method).toBe('PUT');
+      req.flush(mock);
+      expect(result?.device.rack_id).toBe(2);
+    });
+  });
+});

--- a/frontend/src/app/features/racks/rack.service.ts
+++ b/frontend/src/app/features/racks/rack.service.ts
@@ -1,0 +1,143 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Rack, RackSummary, RackTemplate, PlaceDeviceResult } from '../../models';
+
+/** Request body for creating or updating a rack type. */
+export interface RackTypePayload {
+  name: string;
+  description?: string;
+  height_u: number;
+  power_capacity_w: number;
+}
+
+/** Request body for creating a rack. */
+export interface CreateRackPayload {
+  name: string;
+  description?: string;
+  block_id?: number | null;
+  rack_type_id?: number | null;
+  height_u?: number;
+  power_capacity_w?: number;
+}
+
+/** Request body for updating a rack. */
+export interface UpdateRackPayload {
+  name: string;
+  description?: string;
+  block_id?: number | null;
+}
+
+/** Request body for placing a device. */
+export interface PlaceDevicePayload {
+  device_model_id: number;
+  name: string;
+  description?: string;
+  role?: string;
+  position?: number;
+}
+
+/** Request body for moving a device within a rack. */
+export interface MoveDevicePayload {
+  position: number;
+}
+
+/** Request body for moving a device to a different rack. */
+export interface MoveCrossRackPayload {
+  dest_rack_id: number;
+  position?: number;
+}
+
+/**
+ * RackService communicates with the Go REST API for rack types, racks,
+ * and device placement operations.
+ */
+@Injectable({ providedIn: 'root' })
+export class RackService {
+  private readonly http = inject(HttpClient);
+  private readonly rackTypesBase = '/api/rack-types';
+  private readonly racksBase = '/api/racks';
+
+  // --- Rack Types ---
+
+  /** Lists all rack type templates. */
+  listRackTypes(): Observable<RackTemplate[]> {
+    return this.http.get<RackTemplate[]>(this.rackTypesBase);
+  }
+
+  /** Gets a single rack type. */
+  getRackType(id: number): Observable<RackTemplate> {
+    return this.http.get<RackTemplate>(`${this.rackTypesBase}/${id}`);
+  }
+
+  /** Creates a new rack type. */
+  createRackType(payload: RackTypePayload): Observable<RackTemplate> {
+    return this.http.post<RackTemplate>(this.rackTypesBase, payload);
+  }
+
+  /** Updates an existing rack type. */
+  updateRackType(id: number, payload: RackTypePayload): Observable<RackTemplate> {
+    return this.http.put<RackTemplate>(`${this.rackTypesBase}/${id}`, payload);
+  }
+
+  /** Deletes a rack type. Returns 409 if racks reference it. */
+  deleteRackType(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.rackTypesBase}/${id}`);
+  }
+
+  // --- Racks ---
+
+  /** Lists all racks, optionally filtered by block. */
+  listRacks(blockId?: number): Observable<Rack[]> {
+    if (blockId != null) {
+      return this.http.get<Rack[]>(this.racksBase, { params: { block_id: String(blockId) } });
+    }
+    return this.http.get<Rack[]>(this.racksBase);
+  }
+
+  /** Gets a rack with usage summary and device list. */
+  getRack(id: number): Observable<RackSummary> {
+    return this.http.get<RackSummary>(`${this.racksBase}/${id}`);
+  }
+
+  /** Creates a new rack. */
+  createRack(payload: CreateRackPayload): Observable<Rack> {
+    return this.http.post<Rack>(this.racksBase, payload);
+  }
+
+  /** Updates a rack's name, description, and block assignment. */
+  updateRack(id: number, payload: UpdateRackPayload): Observable<Rack> {
+    return this.http.put<Rack>(`${this.racksBase}/${id}`, payload);
+  }
+
+  /** Deletes a rack and all its devices. */
+  deleteRack(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.racksBase}/${id}`);
+  }
+
+  // --- Device Placement ---
+
+  /** Places a device in a rack at the given position. */
+  placeDevice(rackId: number, payload: PlaceDevicePayload): Observable<PlaceDeviceResult> {
+    return this.http.post<PlaceDeviceResult>(`${this.racksBase}/${rackId}/devices`, payload);
+  }
+
+  /** Moves a device to a new position within the same rack. */
+  moveDeviceInRack(rackId: number, deviceId: number, payload: MoveDevicePayload): Observable<PlaceDeviceResult> {
+    return this.http.put<PlaceDeviceResult>(`${this.racksBase}/${rackId}/devices/${deviceId}`, payload);
+  }
+
+  /** Moves a device to a different rack. */
+  moveDeviceCrossRack(rackId: number, deviceId: number, payload: MoveCrossRackPayload): Observable<PlaceDeviceResult> {
+    return this.http.put<PlaceDeviceResult>(`${this.racksBase}/${rackId}/devices/${deviceId}/move`, payload);
+  }
+
+  /**
+   * Removes a device from a rack.
+   * @param compact When true, devices above the gap shift down to fill it.
+   */
+  removeDevice(rackId: number, deviceId: number, compact = false): Observable<void> {
+    const params = { compact: String(compact) };
+    return this.http.delete<void>(`${this.racksBase}/${rackId}/devices/${deviceId}`, { params });
+  }
+}

--- a/frontend/src/app/features/racks/racks.component.ts
+++ b/frontend/src/app/features/racks/racks.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+
+/**
+ * RacksComponent is the shell component for the racks feature.
+ * It delegates all content to child routes via RouterOutlet.
+ */
+@Component({
+  selector: 'app-racks',
+  standalone: true,
+  imports: [RouterOutlet],
+  template: `<router-outlet />`,
+})
+export class RacksComponent {}

--- a/frontend/src/app/features/racks/racks.routes.ts
+++ b/frontend/src/app/features/racks/racks.routes.ts
@@ -1,0 +1,18 @@
+import { Routes } from '@angular/router';
+import { RacksComponent } from './racks.component';
+
+export const RACKS_ROUTES: Routes = [
+  {
+    path: '',
+    component: RacksComponent,
+    children: [
+      {
+        path: '',
+        loadComponent: () =>
+          import('./components/rack-list/rack-list.component').then(
+            m => m.RackListComponent,
+          ),
+      },
+    ],
+  },
+];

--- a/frontend/src/app/models/rack.ts
+++ b/frontend/src/app/models/rack.ts
@@ -1,19 +1,79 @@
 /**
- * RackType mirrors the Go models.RackType enum.
+ * RackTemplate mirrors the Go models.RackTemplate struct.
+ * A RackTemplate is a named template defining rack hardware specifications.
  */
-export type RackType = 'physical' | 'logical';
-
-/**
- * Rack mirrors the Go models.Rack struct.
- * A Rack is a physical or logical rack within a Block.
- */
-export interface Rack {
+export interface RackTemplate {
   id: number;
-  block_id: number;
   name: string;
-  type: RackType;
   height_u: number;
+  power_capacity_w: number;
   description: string;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * Rack mirrors the Go models.Rack struct.
+ * A Rack is a physical rack (optionally within a Block).
+ */
+export interface Rack {
+  id: number;
+  block_id: number | null;
+  rack_type_id: number | null;
+  name: string;
+  height_u: number;
+  power_capacity_w: number;
+  description: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * DeviceSummary mirrors the Go models.DeviceSummary struct.
+ * A DeviceSummary is a device with model info included.
+ */
+export interface DeviceSummary {
+  id: number;
+  rack_id: number;
+  device_model_id: number;
+  name: string;
+  role: string;
+  position: number;
+  description: string;
+  created_at: string;
+  updated_at: string;
+  model_vendor: string;
+  model_name: string;
+  height_u: number;
+  power_watts: number;
+}
+
+/**
+ * RackSummary mirrors the Go models.RackSummary struct.
+ * A RackSummary is a rack with computed usage metrics and device list.
+ */
+export interface RackSummary extends Rack {
+  used_u: number;
+  available_u: number;
+  used_watts: number;
+  devices: DeviceSummary[];
+  warning?: string;
+}
+
+/**
+ * PlaceDeviceResult mirrors the Go models.PlaceDeviceResult struct.
+ */
+export interface PlaceDeviceResult {
+  device: {
+    id: number;
+    rack_id: number;
+    device_model_id: number;
+    name: string;
+    role: string;
+    position: number;
+    description: string;
+    created_at: string;
+    updated_at: string;
+  };
+  warning?: string;
 }

--- a/server/cmd/fabrik/docs/knowledge/infrastructure/rack-modeling.md
+++ b/server/cmd/fabrik/docs/knowledge/infrastructure/rack-modeling.md
@@ -1,0 +1,131 @@
+---
+title: Rack Modeling
+category: infrastructure
+tags: [rack, physical, constraint, capacity, power, RU, placement]
+---
+
+# Rack Modeling
+
+fabrik's rack modeling feature lets you define rack templates, create rack instances, assign devices to specific RU positions, and automatically validate physical constraints — RU capacity and power budget — in real time.
+
+## Core Concepts
+
+### Rack Types (Templates)
+
+A **rack type** is a reusable template that captures the standard specifications for a rack model:
+
+- **Height (U)** — how many rack units the rack provides (e.g., 42U, 24U)
+- **Power Capacity (W)** — the total PDU power budget in watts
+
+When you create a rack from a rack type, the specs are copied into the rack instance. The rack can then diverge from the template (e.g., a custom power limit).
+
+### Rack Instances
+
+A **rack** is a physical installation. It may be:
+
+- **Standalone** — not assigned to a block
+- **Block-assigned** — placed in a logical Block within a Site hierarchy
+
+Each rack tracks:
+- Its inherited or custom height (U) and power capacity (W)
+- All devices currently installed (with their RU positions)
+- Real-time summary of used/available RU and power
+
+### RU Positions
+
+RU positions are **1-indexed from the bottom** of the rack. A 42U rack has positions 1–42. Multi-RU devices (e.g., a 7U chassis) occupy consecutive positions: a device at position 1 with height 7U occupies positions 1–7.
+
+## Constraint Validation
+
+### RU Capacity (Hard Limit)
+
+fabrik rejects any placement that would overflow the rack's RU capacity:
+
+- Device height_u > remaining available U → **400 Bad Request**
+- Requested position + device height − 1 > rack height → **400 Bad Request**
+- Position overlaps an existing device → **400 Bad Request**
+
+Positions must be ≥ 1. Position 0 and negative positions are rejected.
+
+### Power Budget (Soft Limit)
+
+Power is a **soft limit**: oversubscription is allowed, but warned:
+
+- Placing a device that would exceed the rack's power capacity → response includes a `warning` field
+- Rack summary marks a warning when utilization exceeds 80%
+
+This allows for planning headroom and accounting for redundant PSU configurations.
+
+## API Overview
+
+### Rack Types
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/rack-types` | Create a rack type |
+| `GET` | `/api/rack-types` | List all rack types |
+| `GET` | `/api/rack-types/:id` | Get a single rack type |
+| `PUT` | `/api/rack-types/:id` | Update a rack type |
+| `DELETE` | `/api/rack-types/:id` | Delete (409 if racks reference it) |
+
+### Racks
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/racks` | Create a rack (optionally from a type) |
+| `GET` | `/api/racks` | List racks (filter with `?block_id=`) |
+| `GET` | `/api/racks/:id` | Get rack with usage summary |
+| `PUT` | `/api/racks/:id` | Update name, description, block |
+| `DELETE` | `/api/racks/:id` | Delete rack (cascades to devices) |
+
+### Device Placement
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/racks/:id/devices` | Place device (auto-suggests position if omitted) |
+| `PUT` | `/api/racks/:rack_id/devices/:device_id` | Move device within the same rack |
+| `PUT` | `/api/racks/:rack_id/devices/:device_id/move` | Move device to a different rack |
+| `DELETE` | `/api/racks/:rack_id/devices/:device_id` | Remove device (`?compact=true` to shift others down) |
+
+## Rack Summary Response
+
+`GET /api/racks/:id` returns an enriched summary:
+
+```json
+{
+  "id": 1,
+  "name": "row-a-rack-01",
+  "height_u": 42,
+  "power_capacity_w": 10000,
+  "used_u": 8,
+  "available_u": 34,
+  "used_watts": 1800,
+  "warning": "power utilization at 82% (8200W / 10000W)",
+  "devices": [
+    {
+      "id": 5,
+      "name": "spine-01",
+      "position": 1,
+      "height_u": 2,
+      "power_watts": 900,
+      "model_vendor": "Arista",
+      "model_name": "7050TX-64",
+      "role": "spine"
+    }
+  ]
+}
+```
+
+## Device Removal: Compact Mode
+
+When removing a device, pass `?compact=true` to shift all devices above the removed device's slot downward, filling the gap. Use `?compact=false` (default) to leave the gap empty and preserve existing positions.
+
+## Cross-Rack Moves
+
+To move a device from one rack to another, `PUT /api/racks/:src_rack_id/devices/:device_id/move` with the body:
+
+```json
+{ "dest_rack_id": 2, "position": 5 }
+```
+
+The same constraint checks apply to the destination rack. If `position` is omitted (or 0), fabrik auto-suggests the lowest available slot.

--- a/server/cmd/fabrik/main.go
+++ b/server/cmd/fabrik/main.go
@@ -44,6 +44,12 @@ func main() {
 	deviceModelSvc := service.NewDeviceModelService(deviceModelStore)
 	deviceModelHandler := handlers.NewDeviceModelHandler(deviceModelSvc)
 
+	// Wire up rack types and racks
+	rackTypeStore := store.NewRackTypeStore(db)
+	rackStore := store.NewRackStore(db)
+	rackSvc := service.NewRackService(rackTypeStore, rackStore)
+	rackHandler := handlers.NewRackHandler(rackSvc)
+
 	// Wire up knowledge base
 	knowledgeSub, err := fs.Sub(docsFS, "docs/knowledge")
 	if err != nil {
@@ -62,7 +68,7 @@ func main() {
 	})
 
 	// Register domain routes
-	api.RegisterRoutes(mux, designHandler, knowledgeHandler, deviceModelHandler)
+	api.RegisterRoutes(mux, designHandler, knowledgeHandler, deviceModelHandler, rackHandler)
 
 	addr := ":8080"
 	if port := os.Getenv("FABRIK_PORT"); port != "" {

--- a/server/internal/api/handlers/racks.go
+++ b/server/internal/api/handlers/racks.go
@@ -1,0 +1,462 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/rnwolfe/fabrik/server/internal/models"
+)
+
+// RackService is the business logic interface required by RackHandler.
+type RackService interface {
+	// Rack type operations
+	CreateRackType(name, description string, heightU, powerCapacityW int) (*models.RackTemplate, error)
+	ListRackTypes() ([]*models.RackTemplate, error)
+	GetRackType(id int64) (*models.RackTemplate, error)
+	UpdateRackType(id int64, name, description string, heightU, powerCapacityW int) (*models.RackTemplate, error)
+	DeleteRackType(id int64) error
+	// Rack operations
+	CreateRack(name, description string, blockID, rackTypeID *int64, heightU, powerCapacityW int) (*models.Rack, error)
+	ListRacks(blockID *int64) ([]*models.Rack, error)
+	GetRackSummary(id int64) (*models.RackSummary, error)
+	UpdateRack(id int64, name, description string, blockID *int64) (*models.Rack, error)
+	DeleteRack(id int64) error
+	// Device placement
+	PlaceDevice(rackID, deviceModelID int64, name, description, role string, position int) (*models.PlaceDeviceResult, error)
+	MoveDeviceInRack(rackID, deviceID int64, newPosition int) (*models.PlaceDeviceResult, error)
+	MoveDeviceCrossRack(srcRackID, deviceID, dstRackID int64, newPosition int) (*models.PlaceDeviceResult, error)
+	RemoveDevice(rackID, deviceID int64, compact bool) error
+}
+
+// RackHandler handles HTTP requests for rack type and rack resources.
+type RackHandler struct {
+	svc RackService
+}
+
+// NewRackHandler returns a new RackHandler using svc.
+func NewRackHandler(svc RackService) *RackHandler {
+	return &RackHandler{svc: svc}
+}
+
+// --- Rack Type handlers ---
+
+type createRackTypeRequest struct {
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	HeightU        int    `json:"height_u"`
+	PowerCapacityW int    `json:"power_capacity_w"`
+}
+
+// CreateRackType handles POST /api/rack-types.
+func (h *RackHandler) CreateRackType(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req createRackTypeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	rt, err := h.svc.CreateRackType(req.Name, req.Description, req.HeightU, req.PowerCapacityW)
+	if err != nil {
+		if errors.Is(err, models.ErrConstraintViolation) {
+			writeError(w, http.StatusUnprocessableEntity, err.Error())
+			return
+		}
+		slog.Error("create rack type", "err", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, rt)
+}
+
+// ListRackTypes handles GET /api/rack-types.
+func (h *RackHandler) ListRackTypes(w http.ResponseWriter, r *http.Request) {
+	rts, err := h.svc.ListRackTypes()
+	if err != nil {
+		slog.Error("list rack types", "err", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	if rts == nil {
+		rts = []*models.RackTemplate{}
+	}
+	writeJSON(w, http.StatusOK, rts)
+}
+
+// GetRackType handles GET /api/rack-types/:id.
+func (h *RackHandler) GetRackType(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r, "id")
+	if !ok {
+		return
+	}
+	rt, err := h.svc.GetRackType(id)
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "rack type not found")
+			return
+		}
+		slog.Error("get rack type", "err", err, "rackTypeID", id)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, rt)
+}
+
+// UpdateRackType handles PUT /api/rack-types/:id.
+func (h *RackHandler) UpdateRackType(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r, "id")
+	if !ok {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req createRackTypeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	rt, err := h.svc.UpdateRackType(id, req.Name, req.Description, req.HeightU, req.PowerCapacityW)
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "rack type not found")
+			return
+		}
+		if errors.Is(err, models.ErrConstraintViolation) {
+			writeError(w, http.StatusUnprocessableEntity, err.Error())
+			return
+		}
+		slog.Error("update rack type", "err", err, "rackTypeID", id)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, rt)
+}
+
+// DeleteRackType handles DELETE /api/rack-types/:id.
+func (h *RackHandler) DeleteRackType(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r, "id")
+	if !ok {
+		return
+	}
+	if err := h.svc.DeleteRackType(id); err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "rack type not found")
+			return
+		}
+		if errors.Is(err, models.ErrConflict) {
+			writeError(w, http.StatusConflict, err.Error())
+			return
+		}
+		slog.Error("delete rack type", "err", err, "rackTypeID", id)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Rack handlers ---
+
+type createRackRequest struct {
+	Name           string  `json:"name"`
+	Description    string  `json:"description"`
+	BlockID        *int64  `json:"block_id"`
+	RackTypeID     *int64  `json:"rack_type_id"`
+	HeightU        int     `json:"height_u"`
+	PowerCapacityW int     `json:"power_capacity_w"`
+}
+
+// CreateRack handles POST /api/racks.
+func (h *RackHandler) CreateRack(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req createRackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	rack, err := h.svc.CreateRack(req.Name, req.Description, req.BlockID, req.RackTypeID, req.HeightU, req.PowerCapacityW)
+	if err != nil {
+		if errors.Is(err, models.ErrConstraintViolation) {
+			writeError(w, http.StatusUnprocessableEntity, err.Error())
+			return
+		}
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		slog.Error("create rack", "err", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, rack)
+}
+
+// ListRacks handles GET /api/racks with optional ?block_id= filter.
+func (h *RackHandler) ListRacks(w http.ResponseWriter, r *http.Request) {
+	var blockID *int64
+	if v := r.URL.Query().Get("block_id"); v != "" {
+		id, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid block_id")
+			return
+		}
+		blockID = &id
+	}
+
+	racks, err := h.svc.ListRacks(blockID)
+	if err != nil {
+		slog.Error("list racks", "err", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	if racks == nil {
+		racks = []*models.Rack{}
+	}
+	writeJSON(w, http.StatusOK, racks)
+}
+
+// GetRack handles GET /api/racks/:id (returns summary).
+func (h *RackHandler) GetRack(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r, "id")
+	if !ok {
+		return
+	}
+	summary, err := h.svc.GetRackSummary(id)
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "rack not found")
+			return
+		}
+		slog.Error("get rack", "err", err, "rackID", id)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, summary)
+}
+
+type updateRackRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	BlockID     *int64 `json:"block_id"`
+}
+
+// UpdateRack handles PUT /api/racks/:id.
+func (h *RackHandler) UpdateRack(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r, "id")
+	if !ok {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req updateRackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	rack, err := h.svc.UpdateRack(id, req.Name, req.Description, req.BlockID)
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "rack not found")
+			return
+		}
+		if errors.Is(err, models.ErrConstraintViolation) {
+			writeError(w, http.StatusUnprocessableEntity, err.Error())
+			return
+		}
+		slog.Error("update rack", "err", err, "rackID", id)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, rack)
+}
+
+// DeleteRack handles DELETE /api/racks/:id.
+func (h *RackHandler) DeleteRack(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r, "id")
+	if !ok {
+		return
+	}
+	if err := h.svc.DeleteRack(id); err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "rack not found")
+			return
+		}
+		slog.Error("delete rack", "err", err, "rackID", id)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Device placement handlers ---
+
+type placeDeviceRequest struct {
+	DeviceModelID int64  `json:"device_model_id"`
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	Role          string `json:"role"`
+	Position      int    `json:"position"`
+}
+
+// PlaceDevice handles POST /api/racks/:id/devices.
+func (h *RackHandler) PlaceDevice(w http.ResponseWriter, r *http.Request) {
+	rackID, ok := parseID(w, r, "id")
+	if !ok {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req placeDeviceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	result, err := h.svc.PlaceDevice(rackID, req.DeviceModelID, req.Name, req.Description, req.Role, req.Position)
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if errors.Is(err, models.ErrRUOverflow) || errors.Is(err, models.ErrPositionOverlap) || errors.Is(err, models.ErrConstraintViolation) {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		slog.Error("place device", "err", err, "rackID", rackID)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, result)
+}
+
+type moveDeviceRequest struct {
+	Position int `json:"position"`
+}
+
+// MoveDeviceInRack handles PUT /api/racks/:rack_id/devices/:device_id.
+func (h *RackHandler) MoveDeviceInRack(w http.ResponseWriter, r *http.Request) {
+	rackID, ok := parseID(w, r, "rack_id")
+	if !ok {
+		return
+	}
+	deviceID, ok := parseID(w, r, "device_id")
+	if !ok {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req moveDeviceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	result, err := h.svc.MoveDeviceInRack(rackID, deviceID, req.Position)
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if errors.Is(err, models.ErrRUOverflow) || errors.Is(err, models.ErrPositionOverlap) || errors.Is(err, models.ErrConstraintViolation) {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		slog.Error("move device in rack", "err", err, "rackID", rackID, "deviceID", deviceID)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+type moveCrossRackRequest struct {
+	DestRackID int64 `json:"dest_rack_id"`
+	Position   int   `json:"position"`
+}
+
+// MoveDeviceCrossRack handles PUT /api/racks/:rack_id/devices/:device_id/move.
+func (h *RackHandler) MoveDeviceCrossRack(w http.ResponseWriter, r *http.Request) {
+	rackID, ok := parseID(w, r, "rack_id")
+	if !ok {
+		return
+	}
+	deviceID, ok := parseID(w, r, "device_id")
+	if !ok {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req moveCrossRackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	result, err := h.svc.MoveDeviceCrossRack(rackID, deviceID, req.DestRackID, req.Position)
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if errors.Is(err, models.ErrRUOverflow) || errors.Is(err, models.ErrPositionOverlap) || errors.Is(err, models.ErrConstraintViolation) {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		slog.Error("move device cross-rack", "err", err, "rackID", rackID, "deviceID", deviceID)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+// RemoveDevice handles DELETE /api/racks/:rack_id/devices/:device_id.
+func (h *RackHandler) RemoveDevice(w http.ResponseWriter, r *http.Request) {
+	rackID, ok := parseID(w, r, "rack_id")
+	if !ok {
+		return
+	}
+	deviceID, ok := parseID(w, r, "device_id")
+	if !ok {
+		return
+	}
+	compact := r.URL.Query().Get("compact") == "true"
+	if err := h.svc.RemoveDevice(rackID, deviceID, compact); err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		slog.Error("remove device", "err", err, "rackID", rackID, "deviceID", deviceID)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/internal/api/handlers/racks_test.go
+++ b/server/internal/api/handlers/racks_test.go
@@ -1,0 +1,557 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rnwolfe/fabrik/server/internal/api/handlers"
+	"github.com/rnwolfe/fabrik/server/internal/models"
+)
+
+// fakeRackService is an in-memory stub implementing handlers.RackService.
+type fakeRackService struct {
+	rackTypes    map[int64]*models.RackTemplate
+	racks        map[int64]*models.Rack
+	devices      map[int64]*models.Device
+	nextTypeID   int64
+	nextRackID   int64
+	nextDeviceID int64
+}
+
+func newFakeRackSvc() *fakeRackService {
+	return &fakeRackService{
+		rackTypes: make(map[int64]*models.RackTemplate),
+		racks:     make(map[int64]*models.Rack),
+		devices:   make(map[int64]*models.Device),
+	}
+}
+
+func (s *fakeRackService) CreateRackType(name, description string, heightU, powerCapacityW int) (*models.RackTemplate, error) {
+	if name == "" {
+		return nil, fmt.Errorf("%w: rack type name is required", models.ErrConstraintViolation)
+	}
+	if heightU <= 0 {
+		return nil, fmt.Errorf("%w: height_u must be positive", models.ErrConstraintViolation)
+	}
+	s.nextTypeID++
+	rt := &models.RackTemplate{ID: s.nextTypeID, Name: name, HeightU: heightU, PowerCapacityW: powerCapacityW}
+	s.rackTypes[rt.ID] = rt
+	return rt, nil
+}
+
+func (s *fakeRackService) ListRackTypes() ([]*models.RackTemplate, error) {
+	out := make([]*models.RackTemplate, 0, len(s.rackTypes))
+	for _, rt := range s.rackTypes {
+		cp := *rt
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (s *fakeRackService) GetRackType(id int64) (*models.RackTemplate, error) {
+	rt, ok := s.rackTypes[id]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	cp := *rt
+	return &cp, nil
+}
+
+func (s *fakeRackService) UpdateRackType(id int64, name, description string, heightU, powerCapacityW int) (*models.RackTemplate, error) {
+	rt, ok := s.rackTypes[id]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	if name == "" {
+		return nil, fmt.Errorf("%w: name required", models.ErrConstraintViolation)
+	}
+	rt.Name = name
+	rt.HeightU = heightU
+	cp := *rt
+	return &cp, nil
+}
+
+func (s *fakeRackService) DeleteRackType(id int64) error {
+	if _, ok := s.rackTypes[id]; !ok {
+		return models.ErrNotFound
+	}
+	// Simulate conflict: check if any rack uses it.
+	for _, r := range s.racks {
+		if r.RackTypeID != nil && *r.RackTypeID == id {
+			return fmt.Errorf("%w: rack type is referenced", models.ErrConflict)
+		}
+	}
+	delete(s.rackTypes, id)
+	return nil
+}
+
+func (s *fakeRackService) CreateRack(name, description string, blockID, rackTypeID *int64, heightU, powerCapacityW int) (*models.Rack, error) {
+	if name == "" {
+		return nil, fmt.Errorf("%w: rack name required", models.ErrConstraintViolation)
+	}
+	if heightU == 0 {
+		heightU = 42
+	}
+	s.nextRackID++
+	r := &models.Rack{ID: s.nextRackID, Name: name, HeightU: heightU, PowerCapacityW: powerCapacityW, BlockID: blockID, RackTypeID: rackTypeID}
+	s.racks[r.ID] = r
+	return r, nil
+}
+
+func (s *fakeRackService) ListRacks(blockID *int64) ([]*models.Rack, error) {
+	out := make([]*models.Rack, 0)
+	for _, r := range s.racks {
+		if blockID != nil {
+			if r.BlockID == nil || *r.BlockID != *blockID {
+				continue
+			}
+		}
+		cp := *r
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (s *fakeRackService) GetRackSummary(id int64) (*models.RackSummary, error) {
+	r, ok := s.racks[id]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	cp := *r
+	return &models.RackSummary{Rack: cp, Devices: []*models.DeviceSummary{}}, nil
+}
+
+func (s *fakeRackService) UpdateRack(id int64, name, description string, blockID *int64) (*models.Rack, error) {
+	r, ok := s.racks[id]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	if name == "" {
+		return nil, fmt.Errorf("%w: name required", models.ErrConstraintViolation)
+	}
+	r.Name = name
+	cp := *r
+	return &cp, nil
+}
+
+func (s *fakeRackService) DeleteRack(id int64) error {
+	if _, ok := s.racks[id]; !ok {
+		return models.ErrNotFound
+	}
+	delete(s.racks, id)
+	return nil
+}
+
+func (s *fakeRackService) PlaceDevice(rackID, deviceModelID int64, name, description, role string, position int) (*models.PlaceDeviceResult, error) {
+	if _, ok := s.racks[rackID]; !ok {
+		return nil, models.ErrNotFound
+	}
+	s.nextDeviceID++
+	d := &models.Device{ID: s.nextDeviceID, RackID: rackID, DeviceModelID: deviceModelID, Name: name, Position: position}
+	s.devices[d.ID] = d
+	return &models.PlaceDeviceResult{Device: d}, nil
+}
+
+func (s *fakeRackService) MoveDeviceInRack(rackID, deviceID int64, newPosition int) (*models.PlaceDeviceResult, error) {
+	d, ok := s.devices[deviceID]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	d.Position = newPosition
+	cp := *d
+	return &models.PlaceDeviceResult{Device: &cp}, nil
+}
+
+func (s *fakeRackService) MoveDeviceCrossRack(srcRackID, deviceID, dstRackID int64, newPosition int) (*models.PlaceDeviceResult, error) {
+	d, ok := s.devices[deviceID]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	d.RackID = dstRackID
+	d.Position = newPosition
+	cp := *d
+	return &models.PlaceDeviceResult{Device: &cp}, nil
+}
+
+func (s *fakeRackService) RemoveDevice(rackID, deviceID int64, compact bool) error {
+	if _, ok := s.devices[deviceID]; !ok {
+		return models.ErrNotFound
+	}
+	delete(s.devices, deviceID)
+	return nil
+}
+
+// --- Tests ---
+
+func TestRackHandler_CreateRackType(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{name: "valid", body: `{"name":"42U","height_u":42,"power_capacity_w":10000}`, wantStatus: http.StatusCreated},
+		{name: "empty name", body: `{"name":"","height_u":42}`, wantStatus: http.StatusUnprocessableEntity},
+		{name: "zero height", body: `{"name":"x","height_u":0}`, wantStatus: http.StatusUnprocessableEntity},
+		{name: "invalid json", body: `{bad`, wantStatus: http.StatusBadRequest},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := handlers.NewRackHandler(newFakeRackSvc())
+			req := httptest.NewRequest(http.MethodPost, "/api/rack-types", bytes.NewBufferString(tc.body))
+			rec := httptest.NewRecorder()
+			h.CreateRackType(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("expected %d, got %d (body: %s)", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestRackHandler_ListRackTypes(t *testing.T) {
+	svc := newFakeRackSvc()
+	svc.CreateRackType("type1", "", 42, 0)
+	svc.CreateRackType("type2", "", 24, 0)
+
+	h := handlers.NewRackHandler(svc)
+	req := httptest.NewRequest(http.MethodGet, "/api/rack-types", nil)
+	rec := httptest.NewRecorder()
+	h.ListRackTypes(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var rts []models.RackTemplate
+	if err := json.NewDecoder(rec.Body).Decode(&rts); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(rts) != 2 {
+		t.Errorf("expected 2 rack types, got %d", len(rts))
+	}
+}
+
+func TestRackHandler_GetRackType(t *testing.T) {
+	svc := newFakeRackSvc()
+	svc.CreateRackType("get-type", "", 42, 0)
+
+	h := handlers.NewRackHandler(svc)
+
+	t.Run("found", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /api/rack-types/{id}", h.GetRackType)
+		req := httptest.NewRequest(http.MethodGet, "/api/rack-types/1", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /api/rack-types/{id}", h.GetRackType)
+		req := httptest.NewRequest(http.MethodGet, "/api/rack-types/9999", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+}
+
+func TestRackHandler_DeleteRackType_Conflict(t *testing.T) {
+	svc := newFakeRackSvc()
+	svc.CreateRackType("type1", "", 42, 0)
+	typeID := int64(1)
+	// Create a rack referencing the type.
+	svc.CreateRack("rack1", "", nil, &typeID, 42, 0)
+
+	h := handlers.NewRackHandler(svc)
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /api/rack-types/{id}", h.DeleteRackType)
+	req := httptest.NewRequest(http.MethodDelete, "/api/rack-types/1", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("expected 409 conflict, got %d (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRackHandler_CreateRack(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{name: "valid", body: `{"name":"rack-01","height_u":42,"power_capacity_w":5000}`, wantStatus: http.StatusCreated},
+		{name: "empty name", body: `{"name":"","height_u":42}`, wantStatus: http.StatusUnprocessableEntity},
+		{name: "invalid json", body: `{bad`, wantStatus: http.StatusBadRequest},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := handlers.NewRackHandler(newFakeRackSvc())
+			req := httptest.NewRequest(http.MethodPost, "/api/racks", bytes.NewBufferString(tc.body))
+			rec := httptest.NewRecorder()
+			h.CreateRack(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("expected %d, got %d (body: %s)", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestRackHandler_GetRack(t *testing.T) {
+	svc := newFakeRackSvc()
+	svc.CreateRack("rack-01", "", nil, nil, 42, 0)
+
+	h := handlers.NewRackHandler(svc)
+
+	t.Run("found", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /api/racks/{id}", h.GetRack)
+		req := httptest.NewRequest(http.MethodGet, "/api/racks/1", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /api/racks/{id}", h.GetRack)
+		req := httptest.NewRequest(http.MethodGet, "/api/racks/9999", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+}
+
+func TestRackHandler_PlaceDevice_ConstraintErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupSvc   func(*fakeRackService)
+		rackID     string
+		body       string
+		wantStatus int
+	}{
+		{
+			name:       "rack not found",
+			setupSvc:   func(s *fakeRackService) {},
+			rackID:     "99",
+			body:       `{"device_model_id":1,"name":"dev","position":1}`,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "place in existing rack",
+			setupSvc: func(s *fakeRackService) {
+				s.CreateRack("rack-1", "", nil, nil, 42, 0)
+			},
+			rackID:     "1",
+			body:       `{"device_model_id":1,"name":"dev","position":1}`,
+			wantStatus: http.StatusCreated,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newFakeRackSvc()
+			tc.setupSvc(svc)
+			h := handlers.NewRackHandler(svc)
+			mux := http.NewServeMux()
+			mux.HandleFunc("POST /api/racks/{id}/devices", h.PlaceDevice)
+			req := httptest.NewRequest(http.MethodPost, "/api/racks/"+tc.rackID+"/devices", bytes.NewBufferString(tc.body))
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("expected %d, got %d (body: %s)", tc.wantStatus, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestRackHandler_PlaceDevice_ConstraintErrorMapping(t *testing.T) {
+	// Test that RU overflow and position overlap return 400.
+	errTests := []struct {
+		name     string
+		svcErr   error
+		wantCode int
+	}{
+		{name: "ru overflow", svcErr: fmt.Errorf("%w: no space", models.ErrRUOverflow), wantCode: http.StatusBadRequest},
+		{name: "position overlap", svcErr: fmt.Errorf("%w: overlap", models.ErrPositionOverlap), wantCode: http.StatusBadRequest},
+	}
+
+	for _, tc := range errTests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &errPlaceDeviceSvc{err: tc.svcErr}
+			h := handlers.NewRackHandler(svc)
+			mux := http.NewServeMux()
+			mux.HandleFunc("POST /api/racks/{id}/devices", h.PlaceDevice)
+			req := httptest.NewRequest(http.MethodPost, "/api/racks/1/devices", bytes.NewBufferString(`{"device_model_id":1,"name":"d","position":1}`))
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != tc.wantCode {
+				t.Errorf("expected %d for %s, got %d", tc.wantCode, tc.name, rec.Code)
+			}
+		})
+	}
+}
+
+func TestRackHandler_PlaceDevice_WarningInResponse(t *testing.T) {
+	svc := &warningPlaceDeviceSvc{}
+	h := handlers.NewRackHandler(svc)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/racks/{id}/devices", h.PlaceDevice)
+	req := httptest.NewRequest(http.MethodPost, "/api/racks/1/devices", bytes.NewBufferString(`{"device_model_id":1,"name":"d","position":1}`))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rec.Code)
+	}
+	var result models.PlaceDeviceResult
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Warning == "" {
+		t.Error("expected warning in response, got empty")
+	}
+}
+
+func TestRackHandler_RemoveDevice(t *testing.T) {
+	svc := newFakeRackSvc()
+	svc.CreateRack("rack-1", "", nil, nil, 42, 0)
+	svc.PlaceDevice(1, 1, "dev", "", "leaf", 1)
+
+	h := handlers.NewRackHandler(svc)
+
+	t.Run("success no compact", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("DELETE /api/racks/{rack_id}/devices/{device_id}", h.RemoveDevice)
+		req := httptest.NewRequest(http.MethodDelete, "/api/racks/1/devices/1", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("expected 204, got %d", rec.Code)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("DELETE /api/racks/{rack_id}/devices/{device_id}", h.RemoveDevice)
+		req := httptest.NewRequest(http.MethodDelete, "/api/racks/1/devices/9999", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.Code)
+		}
+	})
+}
+
+func TestRackHandler_ListRacks_BlockIDFilter(t *testing.T) {
+	svc := newFakeRackSvc()
+	blockID := int64(5)
+	svc.CreateRack("rack-in-block", "", &blockID, nil, 42, 0)
+	svc.CreateRack("rack-standalone", "", nil, nil, 42, 0)
+
+	h := handlers.NewRackHandler(svc)
+	req := httptest.NewRequest(http.MethodGet, "/api/racks?block_id=5", nil)
+	rec := httptest.NewRecorder()
+	h.ListRacks(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var racks []models.Rack
+	if err := json.NewDecoder(rec.Body).Decode(&racks); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(racks) != 1 {
+		t.Errorf("expected 1 rack with block_id=5, got %d", len(racks))
+	}
+}
+
+// --- Helper stubs for error-specific tests ---
+
+type errPlaceDeviceSvc struct {
+	*fakeRackService
+	err error
+}
+
+func (s *errPlaceDeviceSvc) CreateRackType(name, description string, heightU, powerCapacityW int) (*models.RackTemplate, error) {
+	return nil, nil
+}
+func (s *errPlaceDeviceSvc) ListRackTypes() ([]*models.RackTemplate, error) { return nil, nil }
+func (s *errPlaceDeviceSvc) GetRackType(id int64) (*models.RackTemplate, error) {
+	return nil, nil
+}
+func (s *errPlaceDeviceSvc) UpdateRackType(id int64, name, description string, heightU, powerCapacityW int) (*models.RackTemplate, error) {
+	return nil, nil
+}
+func (s *errPlaceDeviceSvc) DeleteRackType(id int64) error { return nil }
+func (s *errPlaceDeviceSvc) CreateRack(name, description string, blockID, rackTypeID *int64, heightU, powerCapacityW int) (*models.Rack, error) {
+	return nil, nil
+}
+func (s *errPlaceDeviceSvc) ListRacks(blockID *int64) ([]*models.Rack, error) { return nil, nil }
+func (s *errPlaceDeviceSvc) GetRackSummary(id int64) (*models.RackSummary, error) {
+	return nil, nil
+}
+func (s *errPlaceDeviceSvc) UpdateRack(id int64, name, description string, blockID *int64) (*models.Rack, error) {
+	return nil, nil
+}
+func (s *errPlaceDeviceSvc) DeleteRack(id int64) error { return nil }
+func (s *errPlaceDeviceSvc) PlaceDevice(rackID, deviceModelID int64, name, description, role string, position int) (*models.PlaceDeviceResult, error) {
+	return nil, s.err
+}
+func (s *errPlaceDeviceSvc) MoveDeviceInRack(rackID, deviceID int64, newPosition int) (*models.PlaceDeviceResult, error) {
+	return nil, nil
+}
+func (s *errPlaceDeviceSvc) MoveDeviceCrossRack(srcRackID, deviceID, dstRackID int64, newPosition int) (*models.PlaceDeviceResult, error) {
+	return nil, nil
+}
+func (s *errPlaceDeviceSvc) RemoveDevice(rackID, deviceID int64, compact bool) error {
+	return errors.New("not implemented")
+}
+
+type warningPlaceDeviceSvc struct{}
+
+func (s *warningPlaceDeviceSvc) CreateRackType(name, description string, heightU, powerCapacityW int) (*models.RackTemplate, error) {
+	return nil, nil
+}
+func (s *warningPlaceDeviceSvc) ListRackTypes() ([]*models.RackTemplate, error)  { return nil, nil }
+func (s *warningPlaceDeviceSvc) GetRackType(id int64) (*models.RackTemplate, error) { return nil, nil }
+func (s *warningPlaceDeviceSvc) UpdateRackType(id int64, name, description string, heightU, powerCapacityW int) (*models.RackTemplate, error) {
+	return nil, nil
+}
+func (s *warningPlaceDeviceSvc) DeleteRackType(id int64) error { return nil }
+func (s *warningPlaceDeviceSvc) CreateRack(name, description string, blockID, rackTypeID *int64, heightU, powerCapacityW int) (*models.Rack, error) {
+	return nil, nil
+}
+func (s *warningPlaceDeviceSvc) ListRacks(blockID *int64) ([]*models.Rack, error) { return nil, nil }
+func (s *warningPlaceDeviceSvc) GetRackSummary(id int64) (*models.RackSummary, error) {
+	return nil, nil
+}
+func (s *warningPlaceDeviceSvc) UpdateRack(id int64, name, description string, blockID *int64) (*models.Rack, error) {
+	return nil, nil
+}
+func (s *warningPlaceDeviceSvc) DeleteRack(id int64) error { return nil }
+func (s *warningPlaceDeviceSvc) PlaceDevice(rackID, deviceModelID int64, name, description, role string, position int) (*models.PlaceDeviceResult, error) {
+	d := &models.Device{ID: 1, RackID: rackID, DeviceModelID: deviceModelID, Name: name, Position: position}
+	return &models.PlaceDeviceResult{Device: d, Warning: "power capacity exceeded: 900W used + 500W new = 1400W > 1000W capacity"}, nil
+}
+func (s *warningPlaceDeviceSvc) MoveDeviceInRack(rackID, deviceID int64, newPosition int) (*models.PlaceDeviceResult, error) {
+	return nil, nil
+}
+func (s *warningPlaceDeviceSvc) MoveDeviceCrossRack(srcRackID, deviceID, dstRackID int64, newPosition int) (*models.PlaceDeviceResult, error) {
+	return nil, nil
+}
+func (s *warningPlaceDeviceSvc) RemoveDevice(rackID, deviceID int64, compact bool) error {
+	return nil
+}

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RegisterRoutes registers all API routes on mux.
-func RegisterRoutes(mux *http.ServeMux, designs *handlers.DesignHandler, knowledge *handlers.KnowledgeHandler, deviceModels *handlers.DeviceModelHandler) {
+func RegisterRoutes(mux *http.ServeMux, designs *handlers.DesignHandler, knowledge *handlers.KnowledgeHandler, deviceModels *handlers.DeviceModelHandler, racks *handlers.RackHandler) {
 	// Design CRUD
 	mux.HandleFunc("POST /api/designs", designs.Create)
 	mux.HandleFunc("GET /api/designs", designs.List)
@@ -26,4 +26,24 @@ func RegisterRoutes(mux *http.ServeMux, designs *handlers.DesignHandler, knowled
 	// Knowledge base
 	mux.HandleFunc("GET /api/knowledge", knowledge.Index)
 	mux.HandleFunc("GET /api/knowledge/{path...}", knowledge.Get)
+
+	// Rack types CRUD
+	mux.HandleFunc("POST /api/rack-types", racks.CreateRackType)
+	mux.HandleFunc("GET /api/rack-types", racks.ListRackTypes)
+	mux.HandleFunc("GET /api/rack-types/{id}", racks.GetRackType)
+	mux.HandleFunc("PUT /api/rack-types/{id}", racks.UpdateRackType)
+	mux.HandleFunc("DELETE /api/rack-types/{id}", racks.DeleteRackType)
+
+	// Rack instances CRUD
+	mux.HandleFunc("POST /api/racks", racks.CreateRack)
+	mux.HandleFunc("GET /api/racks", racks.ListRacks)
+	mux.HandleFunc("GET /api/racks/{id}", racks.GetRack)
+	mux.HandleFunc("PUT /api/racks/{id}", racks.UpdateRack)
+	mux.HandleFunc("DELETE /api/racks/{id}", racks.DeleteRack)
+
+	// Device placement
+	mux.HandleFunc("POST /api/racks/{id}/devices", racks.PlaceDevice)
+	mux.HandleFunc("PUT /api/racks/{rack_id}/devices/{device_id}", racks.MoveDeviceInRack)
+	mux.HandleFunc("PUT /api/racks/{rack_id}/devices/{device_id}/move", racks.MoveDeviceCrossRack)
+	mux.HandleFunc("DELETE /api/racks/{rack_id}/devices/{device_id}", racks.RemoveDevice)
 }

--- a/server/internal/migrations/0003_rack_modeling.down.sql
+++ b/server/internal/migrations/0003_rack_modeling.down.sql
@@ -1,0 +1,24 @@
+-- Reverse rack modeling migration.
+
+-- Rebuild racks table without rack_type_id and power_capacity_w, block_id NOT NULL.
+CREATE TABLE IF NOT EXISTS racks_old (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    block_id    INTEGER NOT NULL REFERENCES blocks(id) ON DELETE CASCADE,
+    name        TEXT    NOT NULL,
+    type        TEXT    NOT NULL CHECK (type IN ('physical', 'logical')),
+    height_u    INTEGER NOT NULL DEFAULT 42,
+    description TEXT    NOT NULL DEFAULT '',
+    created_at  DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at  DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+INSERT INTO racks_old (id, block_id, name, type, height_u, description, created_at, updated_at)
+SELECT id, COALESCE(block_id, 0), name, 'physical', height_u, description, created_at, updated_at
+FROM racks;
+
+DROP TABLE racks;
+ALTER TABLE racks_old RENAME TO racks;
+
+CREATE INDEX IF NOT EXISTS idx_racks_block_id ON racks (block_id);
+
+DROP TABLE IF EXISTS rack_types;

--- a/server/internal/migrations/0003_rack_modeling.up.sql
+++ b/server/internal/migrations/0003_rack_modeling.up.sql
@@ -1,0 +1,38 @@
+-- Rack modeling migration: rack types, enhanced racks, and device placement.
+
+-- Rack type templates (new table)
+CREATE TABLE IF NOT EXISTS rack_types (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    name              TEXT    NOT NULL,
+    height_u          INTEGER NOT NULL DEFAULT 42,
+    power_capacity_w  INTEGER NOT NULL DEFAULT 0,
+    description       TEXT    NOT NULL DEFAULT '',
+    created_at        DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at        DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_rack_types_name ON rack_types (name);
+
+-- Rebuild racks table: make block_id nullable, add rack_type_id and power_capacity_w.
+-- SQLite does not support ALTER COLUMN, so we recreate the table.
+CREATE TABLE IF NOT EXISTS racks_new (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    block_id         INTEGER REFERENCES blocks(id) ON DELETE SET NULL,
+    rack_type_id     INTEGER REFERENCES rack_types(id) ON DELETE SET NULL,
+    name             TEXT    NOT NULL,
+    height_u         INTEGER NOT NULL DEFAULT 42,
+    power_capacity_w INTEGER NOT NULL DEFAULT 0,
+    description      TEXT    NOT NULL DEFAULT '',
+    created_at       DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at       DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+INSERT INTO racks_new (id, block_id, name, height_u, description, created_at, updated_at)
+SELECT id, block_id, name, height_u, description, created_at, updated_at
+FROM racks;
+
+DROP TABLE racks;
+ALTER TABLE racks_new RENAME TO racks;
+
+CREATE INDEX IF NOT EXISTS idx_racks_block_id    ON racks (block_id);
+CREATE INDEX IF NOT EXISTS idx_racks_rack_type_id ON racks (rack_type_id);

--- a/server/internal/models/errors.go
+++ b/server/internal/models/errors.go
@@ -16,4 +16,13 @@ var (
 
 	// ErrSeedReadOnly is returned when a mutation is attempted on a seed device model.
 	ErrSeedReadOnly = errors.New("seed device models are read-only")
+
+	// ErrRUOverflow is returned when a device placement would exceed rack RU capacity (hard limit).
+	ErrRUOverflow = errors.New("RU overflow")
+
+	// ErrPositionOverlap is returned when a device placement would overlap an existing device.
+	ErrPositionOverlap = errors.New("position overlap")
+
+	// ErrConflict is returned when deleting a resource that is referenced by others.
+	ErrConflict = errors.New("conflict")
 )

--- a/server/internal/models/models.go
+++ b/server/internal/models/models.go
@@ -44,24 +44,53 @@ type Block struct {
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 
-// RackType enumerates whether a rack is physical hardware or a logical grouping.
-type RackType string
+// RackTemplate represents a named rack type template that defines hardware specifications.
+type RackTemplate struct {
+	ID             int64     `json:"id"`
+	Name           string    `json:"name"`
+	HeightU        int       `json:"height_u"`
+	PowerCapacityW int       `json:"power_capacity_w"`
+	Description    string    `json:"description"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
 
-const (
-	RackTypePhysical RackType = "physical"
-	RackTypeLogical  RackType = "logical"
-)
-
-// Rack represents a physical or logical rack within a block.
+// Rack represents a physical rack within a block (or standalone).
 type Rack struct {
-	ID          int64     `json:"id"`
-	BlockID     int64     `json:"block_id"`
-	Name        string    `json:"name"`
-	Type        RackType  `json:"type"`
-	HeightU     int       `json:"height_u"`
-	Description string    `json:"description"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID             int64     `json:"id"`
+	BlockID        *int64    `json:"block_id"`
+	RackTypeID     *int64    `json:"rack_type_id"`
+	Name           string    `json:"name"`
+	HeightU        int       `json:"height_u"`
+	PowerCapacityW int       `json:"power_capacity_w"`
+	Description    string    `json:"description"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// RackSummary is a rack with computed usage metrics and device list.
+type RackSummary struct {
+	Rack
+	UsedU       int             `json:"used_u"`
+	AvailableU  int             `json:"available_u"`
+	UsedWatts   int             `json:"used_watts"`
+	Devices     []*DeviceSummary `json:"devices"`
+	Warning     string          `json:"warning,omitempty"`
+}
+
+// DeviceSummary is a device with its model information included.
+type DeviceSummary struct {
+	Device
+	ModelVendor string `json:"model_vendor"`
+	ModelName   string `json:"model_name"`
+	HeightU     int    `json:"height_u"`
+	PowerWatts  int    `json:"power_watts"`
+}
+
+// PlaceDeviceResult is returned when placing or moving a device.
+type PlaceDeviceResult struct {
+	Device  *Device `json:"device"`
+	Warning string  `json:"warning,omitempty"`
 }
 
 // DeviceRole enumerates the role of a device within the network fabric.

--- a/server/internal/service/rack_service.go
+++ b/server/internal/service/rack_service.go
@@ -1,0 +1,525 @@
+package service
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/rnwolfe/fabrik/server/internal/models"
+)
+
+const powerWarningThreshold = 0.80
+
+// RackTypeRepository is the store interface for rack type operations.
+type RackTypeRepository interface {
+	Create(rt *models.RackTemplate) (*models.RackTemplate, error)
+	List() ([]*models.RackTemplate, error)
+	Get(id int64) (*models.RackTemplate, error)
+	Update(rt *models.RackTemplate) (*models.RackTemplate, error)
+	Delete(id int64) error
+	ListRackIDsForType(typeID int64) ([]int64, error)
+}
+
+// RackRepository is the store interface for rack and device placement operations.
+type RackRepository interface {
+	Create(r *models.Rack) (*models.Rack, error)
+	List(blockID *int64) ([]*models.Rack, error)
+	Get(id int64) (*models.Rack, error)
+	Update(r *models.Rack) (*models.Rack, error)
+	Delete(id int64) error
+	PlaceDevice(d *models.Device) (*models.Device, error)
+	GetDevice(id int64) (*models.Device, error)
+	MoveDevice(deviceID, rackID int64, position int) (*models.Device, error)
+	RemoveDevice(deviceID int64, compact bool) error
+	ListDevicesInRack(rackID int64) ([]*models.DeviceSummary, error)
+	GetDeviceModel(id int64) (*models.DeviceModel, error)
+}
+
+// RackService implements business logic for rack types, racks, and device placement.
+type RackService struct {
+	typeRepo RackTypeRepository
+	rackRepo RackRepository
+}
+
+// NewRackService returns a new RackService.
+func NewRackService(typeRepo RackTypeRepository, rackRepo RackRepository) *RackService {
+	return &RackService{typeRepo: typeRepo, rackRepo: rackRepo}
+}
+
+// --- Rack Type operations ---
+
+// CreateRackType validates and creates a new RackTemplate.
+func (s *RackService) CreateRackType(name, description string, heightU, powerCapacityW int) (*models.RackTemplate, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: rack type name is required", models.ErrConstraintViolation)
+	}
+	if heightU <= 0 {
+		return nil, fmt.Errorf("%w: height_u must be positive", models.ErrConstraintViolation)
+	}
+	if powerCapacityW < 0 {
+		return nil, fmt.Errorf("%w: power_capacity_w must be non-negative", models.ErrConstraintViolation)
+	}
+	rt, err := s.typeRepo.Create(&models.RackTemplate{
+		Name:           name,
+		HeightU:        heightU,
+		PowerCapacityW: powerCapacityW,
+		Description:    description,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create rack type: %w", err)
+	}
+	slog.Info("rack type created", "rackTypeID", rt.ID, "name", rt.Name)
+	return rt, nil
+}
+
+// ListRackTypes returns all rack types.
+func (s *RackService) ListRackTypes() ([]*models.RackTemplate, error) {
+	rts, err := s.typeRepo.List()
+	if err != nil {
+		return nil, fmt.Errorf("list rack types: %w", err)
+	}
+	return rts, nil
+}
+
+// GetRackType returns the rack type with the given id.
+func (s *RackService) GetRackType(id int64) (*models.RackTemplate, error) {
+	rt, err := s.typeRepo.Get(id)
+	if err != nil {
+		return nil, fmt.Errorf("get rack type %d: %w", id, err)
+	}
+	return rt, nil
+}
+
+// UpdateRackType updates a rack type's fields.
+func (s *RackService) UpdateRackType(id int64, name, description string, heightU, powerCapacityW int) (*models.RackTemplate, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: rack type name is required", models.ErrConstraintViolation)
+	}
+	if heightU <= 0 {
+		return nil, fmt.Errorf("%w: height_u must be positive", models.ErrConstraintViolation)
+	}
+	if powerCapacityW < 0 {
+		return nil, fmt.Errorf("%w: power_capacity_w must be non-negative", models.ErrConstraintViolation)
+	}
+	rt, err := s.typeRepo.Update(&models.RackTemplate{
+		ID:             id,
+		Name:           name,
+		HeightU:        heightU,
+		PowerCapacityW: powerCapacityW,
+		Description:    description,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("update rack type %d: %w", id, err)
+	}
+	return rt, nil
+}
+
+// DeleteRackType removes a rack type. Returns ErrConflict if racks reference it,
+// with the list of affected rack IDs embedded in the error message.
+func (s *RackService) DeleteRackType(id int64) error {
+	ids, err := s.typeRepo.ListRackIDsForType(id)
+	if err != nil {
+		return fmt.Errorf("list rack ids for type: %w", err)
+	}
+	if len(ids) > 0 {
+		return fmt.Errorf("%w: rack type is referenced by rack IDs %v", models.ErrConflict, ids)
+	}
+	if err := s.typeRepo.Delete(id); err != nil {
+		return fmt.Errorf("delete rack type %d: %w", id, err)
+	}
+	slog.Info("rack type deleted", "rackTypeID", id)
+	return nil
+}
+
+// --- Rack operations ---
+
+// CreateRack creates a new rack, optionally seeding specs from a rack type.
+func (s *RackService) CreateRack(name, description string, blockID, rackTypeID *int64, heightU, powerCapacityW int) (*models.Rack, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: rack name is required", models.ErrConstraintViolation)
+	}
+
+	// If a rack type is provided, copy its specs (rack can diverge afterward).
+	if rackTypeID != nil {
+		rt, err := s.typeRepo.Get(*rackTypeID)
+		if err != nil {
+			return nil, fmt.Errorf("get rack type for rack creation: %w", err)
+		}
+		if heightU == 0 {
+			heightU = rt.HeightU
+		}
+		if powerCapacityW == 0 {
+			powerCapacityW = rt.PowerCapacityW
+		}
+	}
+
+	if heightU <= 0 {
+		heightU = 42
+	}
+
+	r, err := s.rackRepo.Create(&models.Rack{
+		BlockID:        blockID,
+		RackTypeID:     rackTypeID,
+		Name:           name,
+		HeightU:        heightU,
+		PowerCapacityW: powerCapacityW,
+		Description:    description,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create rack: %w", err)
+	}
+	slog.Info("rack created", "rackID", r.ID, "name", r.Name)
+	return r, nil
+}
+
+// ListRacks returns racks, optionally filtered by block.
+func (s *RackService) ListRacks(blockID *int64) ([]*models.Rack, error) {
+	racks, err := s.rackRepo.List(blockID)
+	if err != nil {
+		return nil, fmt.Errorf("list racks: %w", err)
+	}
+	return racks, nil
+}
+
+// GetRackSummary returns a rack with computed usage metrics and device list.
+func (s *RackService) GetRackSummary(id int64) (*models.RackSummary, error) {
+	rack, err := s.rackRepo.Get(id)
+	if err != nil {
+		return nil, fmt.Errorf("get rack %d: %w", id, err)
+	}
+
+	devices, err := s.rackRepo.ListDevicesInRack(id)
+	if err != nil {
+		return nil, fmt.Errorf("list devices in rack %d: %w", id, err)
+	}
+
+	usedU := 0
+	usedWatts := 0
+	for _, d := range devices {
+		usedU += d.HeightU
+		usedWatts += d.PowerWatts
+	}
+
+	summary := &models.RackSummary{
+		Rack:       *rack,
+		UsedU:      usedU,
+		AvailableU: rack.HeightU - usedU,
+		UsedWatts:  usedWatts,
+		Devices:    devices,
+	}
+
+	// Power warning at >80% utilization.
+	if rack.PowerCapacityW > 0 {
+		ratio := float64(usedWatts) / float64(rack.PowerCapacityW)
+		if ratio > powerWarningThreshold {
+			summary.Warning = fmt.Sprintf("power utilization at %.0f%% (%.0fW / %dW)", ratio*100, float64(usedWatts), rack.PowerCapacityW)
+		}
+	}
+
+	if devices == nil {
+		summary.Devices = []*models.DeviceSummary{}
+	}
+
+	return summary, nil
+}
+
+// UpdateRack updates a rack's name, description and block assignment.
+func (s *RackService) UpdateRack(id int64, name, description string, blockID *int64) (*models.Rack, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: rack name is required", models.ErrConstraintViolation)
+	}
+	r, err := s.rackRepo.Update(&models.Rack{
+		ID:          id,
+		Name:        name,
+		Description: description,
+		BlockID:     blockID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("update rack %d: %w", id, err)
+	}
+	return r, nil
+}
+
+// DeleteRack removes a rack (devices cascade automatically via FK).
+func (s *RackService) DeleteRack(id int64) error {
+	if err := s.rackRepo.Delete(id); err != nil {
+		return fmt.Errorf("delete rack %d: %w", id, err)
+	}
+	slog.Info("rack deleted", "rackID", id)
+	return nil
+}
+
+// --- Device placement ---
+
+// PlaceDevice places a device in a rack at a specific position.
+// If position is 0, it auto-suggests the lowest available slot.
+// Returns ErrRUOverflow (hard) if the device doesn't fit.
+// Returns ErrPositionOverlap (hard) if the position is already occupied.
+// Returns a warning in the result if power capacity would be exceeded (soft).
+func (s *RackService) PlaceDevice(rackID, deviceModelID int64, name, description, role string, position int) (*models.PlaceDeviceResult, error) {
+	rack, err := s.rackRepo.Get(rackID)
+	if err != nil {
+		return nil, fmt.Errorf("get rack %d: %w", rackID, err)
+	}
+
+	dm, err := s.rackRepo.GetDeviceModel(deviceModelID)
+	if err != nil {
+		return nil, fmt.Errorf("get device model %d: %w", deviceModelID, err)
+	}
+	if dm.HeightU <= 0 {
+		return nil, fmt.Errorf("%w: device model has invalid height", models.ErrConstraintViolation)
+	}
+
+	existing, err := s.rackRepo.ListDevicesInRack(rackID)
+	if err != nil {
+		return nil, fmt.Errorf("list devices in rack: %w", err)
+	}
+
+	// Compute used RU and power.
+	usedU := 0
+	usedWatts := 0
+	for _, d := range existing {
+		usedU += d.HeightU
+		usedWatts += d.PowerWatts
+	}
+
+	// Hard reject: device doesn't fit at all.
+	if dm.HeightU > rack.HeightU-usedU {
+		return nil, fmt.Errorf("%w: device needs %dU but only %dU available", models.ErrRUOverflow, dm.HeightU, rack.HeightU-usedU)
+	}
+
+	// Auto-suggest position if not specified.
+	if position == 0 {
+		position = suggestPosition(rack.HeightU, existing, dm.HeightU)
+		if position == 0 {
+			return nil, fmt.Errorf("%w: no contiguous %dU slot available", models.ErrRUOverflow, dm.HeightU)
+		}
+	}
+
+	// Validate position bounds.
+	if position < 1 {
+		return nil, fmt.Errorf("%w: position must be >= 1", models.ErrConstraintViolation)
+	}
+	if position+dm.HeightU-1 > rack.HeightU {
+		return nil, fmt.Errorf("%w: device at position %d with height %dU exceeds rack height %dU", models.ErrRUOverflow, position, dm.HeightU, rack.HeightU)
+	}
+
+	// Validate no overlap.
+	if err := checkOverlap(existing, position, dm.HeightU, 0); err != nil {
+		return nil, err
+	}
+
+	if role == "" {
+		role = string(models.DeviceRoleOther)
+	}
+
+	d, err := s.rackRepo.PlaceDevice(&models.Device{
+		RackID:        rackID,
+		DeviceModelID: deviceModelID,
+		Name:          name,
+		Role:          models.DeviceRole(role),
+		Position:      position,
+		Description:   description,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("place device: %w", err)
+	}
+
+	result := &models.PlaceDeviceResult{Device: d}
+
+	// Soft warning: power capacity exceeded or approaching threshold.
+	if rack.PowerCapacityW > 0 {
+		newTotal := usedWatts + dm.PowerWatts
+		if newTotal > rack.PowerCapacityW {
+			result.Warning = fmt.Sprintf("power capacity exceeded: %dW used + %dW new = %dW > %dW capacity",
+				usedWatts, dm.PowerWatts, newTotal, rack.PowerCapacityW)
+		} else if float64(newTotal)/float64(rack.PowerCapacityW) > powerWarningThreshold {
+			result.Warning = fmt.Sprintf("power utilization at %.0f%% (%dW / %dW)",
+				float64(newTotal)/float64(rack.PowerCapacityW)*100, newTotal, rack.PowerCapacityW)
+		}
+	}
+
+	slog.Info("device placed", "rackID", rackID, "deviceID", d.ID, "position", position)
+	return result, nil
+}
+
+// MoveDeviceInRack moves a device to a new position within the same rack.
+func (s *RackService) MoveDeviceInRack(rackID, deviceID int64, newPosition int) (*models.PlaceDeviceResult, error) {
+	rack, err := s.rackRepo.Get(rackID)
+	if err != nil {
+		return nil, fmt.Errorf("get rack %d: %w", rackID, err)
+	}
+
+	device, err := s.rackRepo.GetDevice(deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("get device %d: %w", deviceID, err)
+	}
+	if device.RackID != rackID {
+		return nil, fmt.Errorf("%w: device %d is not in rack %d", models.ErrNotFound, deviceID, rackID)
+	}
+
+	dm, err := s.rackRepo.GetDeviceModel(device.DeviceModelID)
+	if err != nil {
+		return nil, fmt.Errorf("get device model: %w", err)
+	}
+
+	if newPosition < 1 {
+		return nil, fmt.Errorf("%w: position must be >= 1", models.ErrConstraintViolation)
+	}
+	if newPosition+dm.HeightU-1 > rack.HeightU {
+		return nil, fmt.Errorf("%w: device at position %d with height %dU exceeds rack height %dU", models.ErrRUOverflow, newPosition, dm.HeightU, rack.HeightU)
+	}
+
+	existing, err := s.rackRepo.ListDevicesInRack(rackID)
+	if err != nil {
+		return nil, fmt.Errorf("list devices in rack: %w", err)
+	}
+
+	// Check overlap excluding the device being moved.
+	if err := checkOverlap(existing, newPosition, dm.HeightU, deviceID); err != nil {
+		return nil, err
+	}
+
+	d, err := s.rackRepo.MoveDevice(deviceID, rackID, newPosition)
+	if err != nil {
+		return nil, fmt.Errorf("move device: %w", err)
+	}
+
+	return &models.PlaceDeviceResult{Device: d}, nil
+}
+
+// MoveDeviceCrossRack moves a device from one rack to another rack at a given position.
+func (s *RackService) MoveDeviceCrossRack(srcRackID, deviceID, dstRackID int64, newPosition int) (*models.PlaceDeviceResult, error) {
+	srcDevice, err := s.rackRepo.GetDevice(deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("get device %d: %w", deviceID, err)
+	}
+	if srcDevice.RackID != srcRackID {
+		return nil, fmt.Errorf("%w: device %d is not in rack %d", models.ErrNotFound, deviceID, srcRackID)
+	}
+
+	dstRack, err := s.rackRepo.Get(dstRackID)
+	if err != nil {
+		return nil, fmt.Errorf("get destination rack %d: %w", dstRackID, err)
+	}
+
+	dm, err := s.rackRepo.GetDeviceModel(srcDevice.DeviceModelID)
+	if err != nil {
+		return nil, fmt.Errorf("get device model: %w", err)
+	}
+
+	dstDevices, err := s.rackRepo.ListDevicesInRack(dstRackID)
+	if err != nil {
+		return nil, fmt.Errorf("list devices in destination rack: %w", err)
+	}
+
+	usedU := 0
+	usedWatts := 0
+	for _, d := range dstDevices {
+		usedU += d.HeightU
+		usedWatts += d.PowerWatts
+	}
+
+	// Hard reject: doesn't fit in destination rack.
+	if dm.HeightU > dstRack.HeightU-usedU {
+		return nil, fmt.Errorf("%w: device needs %dU but destination rack only has %dU available", models.ErrRUOverflow, dm.HeightU, dstRack.HeightU-usedU)
+	}
+
+	if newPosition == 0 {
+		newPosition = suggestPosition(dstRack.HeightU, dstDevices, dm.HeightU)
+		if newPosition == 0 {
+			return nil, fmt.Errorf("%w: no contiguous %dU slot available in destination rack", models.ErrRUOverflow, dm.HeightU)
+		}
+	}
+
+	if newPosition < 1 {
+		return nil, fmt.Errorf("%w: position must be >= 1", models.ErrConstraintViolation)
+	}
+	if newPosition+dm.HeightU-1 > dstRack.HeightU {
+		return nil, fmt.Errorf("%w: device at position %d with height %dU exceeds destination rack height %dU", models.ErrRUOverflow, newPosition, dm.HeightU, dstRack.HeightU)
+	}
+
+	if err := checkOverlap(dstDevices, newPosition, dm.HeightU, 0); err != nil {
+		return nil, err
+	}
+
+	d, err := s.rackRepo.MoveDevice(deviceID, dstRackID, newPosition)
+	if err != nil {
+		return nil, fmt.Errorf("move device cross-rack: %w", err)
+	}
+
+	result := &models.PlaceDeviceResult{Device: d}
+
+	// Soft warning: power capacity exceeded in destination rack.
+	if dstRack.PowerCapacityW > 0 && usedWatts+dm.PowerWatts > dstRack.PowerCapacityW {
+		result.Warning = fmt.Sprintf("power capacity exceeded in destination rack: %dW used + %dW new = %dW > %dW capacity",
+			usedWatts, dm.PowerWatts, usedWatts+dm.PowerWatts, dstRack.PowerCapacityW)
+	}
+
+	slog.Info("device moved cross-rack", "srcRackID", srcRackID, "dstRackID", dstRackID, "deviceID", deviceID)
+	return result, nil
+}
+
+// RemoveDevice deletes a device from a rack.
+func (s *RackService) RemoveDevice(rackID, deviceID int64, compact bool) error {
+	device, err := s.rackRepo.GetDevice(deviceID)
+	if err != nil {
+		return fmt.Errorf("get device %d: %w", deviceID, err)
+	}
+	if device.RackID != rackID {
+		return fmt.Errorf("%w: device %d is not in rack %d", models.ErrNotFound, deviceID, rackID)
+	}
+	if err := s.rackRepo.RemoveDevice(deviceID, compact); err != nil {
+		return fmt.Errorf("remove device %d: %w", deviceID, err)
+	}
+	slog.Info("device removed", "rackID", rackID, "deviceID", deviceID, "compact", compact)
+	return nil
+}
+
+// --- helpers ---
+
+// checkOverlap returns ErrPositionOverlap if the given position+height range overlaps
+// any existing device (excluding skipDeviceID, use 0 to skip nothing).
+func checkOverlap(existing []*models.DeviceSummary, position, heightU int, skipDeviceID int64) error {
+	for _, d := range existing {
+		if d.Device.ID == skipDeviceID {
+			continue
+		}
+		// Overlap if ranges intersect: [position, position+heightU) ∩ [d.Position, d.Position+d.HeightU)
+		if position < d.Device.Position+d.HeightU && position+heightU > d.Device.Position {
+			return fmt.Errorf("%w: position %d overlaps device %d at position %d (height %dU)",
+				models.ErrPositionOverlap, position, d.Device.ID, d.Device.Position, d.HeightU)
+		}
+	}
+	return nil
+}
+
+// suggestPosition returns the lowest RU position that can accommodate a device of the given height.
+// Returns 0 if no slot is available.
+func suggestPosition(rackHeightU int, existing []*models.DeviceSummary, neededU int) int {
+	// Build a set of occupied positions.
+	occupied := make(map[int]bool)
+	for _, d := range existing {
+		for u := d.Device.Position; u < d.Device.Position+d.HeightU; u++ {
+			occupied[u] = true
+		}
+	}
+
+	for start := 1; start <= rackHeightU-neededU+1; start++ {
+		fits := true
+		for u := start; u < start+neededU; u++ {
+			if occupied[u] {
+				fits = false
+				break
+			}
+		}
+		if fits {
+			return start
+		}
+	}
+	return 0
+}

--- a/server/internal/service/rack_service_test.go
+++ b/server/internal/service/rack_service_test.go
@@ -1,0 +1,594 @@
+package service_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rnwolfe/fabrik/server/internal/models"
+	"github.com/rnwolfe/fabrik/server/internal/service"
+)
+
+// --- Fake rack type repository ---
+
+type fakeRackTypeRepo struct {
+	types  map[int64]*models.RackTemplate
+	nextID int64
+}
+
+func newFakeRackTypeRepo() *fakeRackTypeRepo {
+	return &fakeRackTypeRepo{types: make(map[int64]*models.RackTemplate)}
+}
+
+func (r *fakeRackTypeRepo) Create(rt *models.RackTemplate) (*models.RackTemplate, error) {
+	r.nextID++
+	out := *rt
+	out.ID = r.nextID
+	r.types[out.ID] = &out
+	return &out, nil
+}
+
+func (r *fakeRackTypeRepo) List() ([]*models.RackTemplate, error) {
+	out := make([]*models.RackTemplate, 0, len(r.types))
+	for _, rt := range r.types {
+		cp := *rt
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (r *fakeRackTypeRepo) Get(id int64) (*models.RackTemplate, error) {
+	rt, ok := r.types[id]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	cp := *rt
+	return &cp, nil
+}
+
+func (r *fakeRackTypeRepo) Update(rt *models.RackTemplate) (*models.RackTemplate, error) {
+	if _, ok := r.types[rt.ID]; !ok {
+		return nil, models.ErrNotFound
+	}
+	cp := *rt
+	r.types[rt.ID] = &cp
+	return &cp, nil
+}
+
+func (r *fakeRackTypeRepo) Delete(id int64) error {
+	if _, ok := r.types[id]; !ok {
+		return models.ErrNotFound
+	}
+	delete(r.types, id)
+	return nil
+}
+
+func (r *fakeRackTypeRepo) ListRackIDsForType(typeID int64) ([]int64, error) {
+	return nil, nil
+}
+
+// --- Fake rack repository ---
+
+type fakeRackRepo struct {
+	racks        map[int64]*models.Rack
+	devices      map[int64]*models.Device
+	deviceModels map[int64]*models.DeviceModel
+	nextRackID   int64
+	nextDeviceID int64
+}
+
+func newFakeRackRepo() *fakeRackRepo {
+	return &fakeRackRepo{
+		racks:        make(map[int64]*models.Rack),
+		devices:      make(map[int64]*models.Device),
+		deviceModels: make(map[int64]*models.DeviceModel),
+	}
+}
+
+func (r *fakeRackRepo) addDeviceModel(dm *models.DeviceModel) int64 {
+	r.nextDeviceID++
+	dm.ID = r.nextDeviceID
+	r.deviceModels[dm.ID] = dm
+	r.nextDeviceID++ // bump so IDs don't collide with devices
+	return dm.ID
+}
+
+func (r *fakeRackRepo) Create(rack *models.Rack) (*models.Rack, error) {
+	r.nextRackID++
+	out := *rack
+	out.ID = r.nextRackID
+	r.racks[out.ID] = &out
+	return &out, nil
+}
+
+func (r *fakeRackRepo) List(blockID *int64) ([]*models.Rack, error) {
+	out := make([]*models.Rack, 0)
+	for _, rack := range r.racks {
+		if blockID != nil {
+			if rack.BlockID == nil || *rack.BlockID != *blockID {
+				continue
+			}
+		}
+		cp := *rack
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (r *fakeRackRepo) Get(id int64) (*models.Rack, error) {
+	rack, ok := r.racks[id]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	cp := *rack
+	return &cp, nil
+}
+
+func (r *fakeRackRepo) Update(rack *models.Rack) (*models.Rack, error) {
+	existing, ok := r.racks[rack.ID]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	existing.Name = rack.Name
+	existing.Description = rack.Description
+	existing.BlockID = rack.BlockID
+	cp := *existing
+	return &cp, nil
+}
+
+func (r *fakeRackRepo) Delete(id int64) error {
+	if _, ok := r.racks[id]; !ok {
+		return models.ErrNotFound
+	}
+	delete(r.racks, id)
+	// Cascade delete devices.
+	for id2, d := range r.devices {
+		if d.RackID == id {
+			delete(r.devices, id2)
+		}
+	}
+	return nil
+}
+
+func (r *fakeRackRepo) PlaceDevice(d *models.Device) (*models.Device, error) {
+	r.nextDeviceID++
+	out := *d
+	out.ID = r.nextDeviceID
+	r.devices[out.ID] = &out
+	return &out, nil
+}
+
+func (r *fakeRackRepo) GetDevice(id int64) (*models.Device, error) {
+	d, ok := r.devices[id]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	cp := *d
+	return &cp, nil
+}
+
+func (r *fakeRackRepo) MoveDevice(deviceID, rackID int64, position int) (*models.Device, error) {
+	d, ok := r.devices[deviceID]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	d.RackID = rackID
+	d.Position = position
+	cp := *d
+	return &cp, nil
+}
+
+func (r *fakeRackRepo) RemoveDevice(deviceID int64, compact bool) error {
+	d, ok := r.devices[deviceID]
+	if !ok {
+		return models.ErrNotFound
+	}
+	dm := r.deviceModels[d.DeviceModelID]
+	heightU := 1
+	if dm != nil {
+		heightU = dm.HeightU
+	}
+	removedPos := d.Position
+	rackID := d.RackID
+	delete(r.devices, deviceID)
+
+	if compact {
+		for _, other := range r.devices {
+			if other.RackID == rackID && other.Position > removedPos {
+				other.Position -= heightU
+			}
+		}
+	}
+	return nil
+}
+
+func (r *fakeRackRepo) ListDevicesInRack(rackID int64) ([]*models.DeviceSummary, error) {
+	var out []*models.DeviceSummary
+	for _, d := range r.devices {
+		if d.RackID != rackID {
+			continue
+		}
+		dm := r.deviceModels[d.DeviceModelID]
+		heightU := 1
+		powerWatts := 0
+		vendor := ""
+		modelName := ""
+		if dm != nil {
+			heightU = dm.HeightU
+			powerWatts = dm.PowerWatts
+			vendor = dm.Vendor
+			modelName = dm.Model
+		}
+		cp := *d
+		out = append(out, &models.DeviceSummary{
+			Device:      cp,
+			ModelVendor: vendor,
+			ModelName:   modelName,
+			HeightU:     heightU,
+			PowerWatts:  powerWatts,
+		})
+	}
+	return out, nil
+}
+
+func (r *fakeRackRepo) GetDeviceModel(id int64) (*models.DeviceModel, error) {
+	dm, ok := r.deviceModels[id]
+	if !ok {
+		return nil, models.ErrNotFound
+	}
+	cp := *dm
+	return &cp, nil
+}
+
+// --- Tests ---
+
+func newRackSvc() (*service.RackService, *fakeRackTypeRepo, *fakeRackRepo) {
+	tr := newFakeRackTypeRepo()
+	rr := newFakeRackRepo()
+	return service.NewRackService(tr, rr), tr, rr
+}
+
+func TestRackService_RackTypeCRUD(t *testing.T) {
+	svc, _, _ := newRackSvc()
+
+	t.Run("create valid", func(t *testing.T) {
+		rt, err := svc.CreateRackType("42U-standard", "desc", 42, 10000)
+		if err != nil {
+			t.Fatalf("CreateRackType: %v", err)
+		}
+		if rt.ID == 0 {
+			t.Error("expected non-zero ID")
+		}
+		if rt.Name != "42U-standard" {
+			t.Errorf("expected name %q, got %q", "42U-standard", rt.Name)
+		}
+	})
+
+	t.Run("create empty name", func(t *testing.T) {
+		_, err := svc.CreateRackType("", "", 42, 0)
+		if !errors.Is(err, models.ErrConstraintViolation) {
+			t.Errorf("expected ErrConstraintViolation, got %v", err)
+		}
+	})
+
+	t.Run("create zero height", func(t *testing.T) {
+		_, err := svc.CreateRackType("name", "", 0, 0)
+		if !errors.Is(err, models.ErrConstraintViolation) {
+			t.Errorf("expected ErrConstraintViolation, got %v", err)
+		}
+	})
+
+	t.Run("create negative power", func(t *testing.T) {
+		_, err := svc.CreateRackType("name", "", 42, -1)
+		if !errors.Is(err, models.ErrConstraintViolation) {
+			t.Errorf("expected ErrConstraintViolation, got %v", err)
+		}
+	})
+
+	t.Run("delete with no racks", func(t *testing.T) {
+		rt, _ := svc.CreateRackType("delete-me", "", 42, 0)
+		if err := svc.DeleteRackType(rt.ID); err != nil {
+			t.Fatalf("DeleteRackType: %v", err)
+		}
+	})
+}
+
+func TestRackService_RackCRUD(t *testing.T) {
+	svc, _, _ := newRackSvc()
+
+	t.Run("create standalone rack", func(t *testing.T) {
+		r, err := svc.CreateRack("rack-01", "desc", nil, nil, 42, 5000)
+		if err != nil {
+			t.Fatalf("CreateRack: %v", err)
+		}
+		if r.ID == 0 {
+			t.Error("expected non-zero ID")
+		}
+		if r.HeightU != 42 {
+			t.Errorf("expected HeightU 42, got %d", r.HeightU)
+		}
+	})
+
+	t.Run("create with rack type inherits specs", func(t *testing.T) {
+		svc2, tr, _ := newRackSvc()
+		rt, _ := tr.Create(&models.RackTemplate{Name: "type1", HeightU: 24, PowerCapacityW: 3000})
+		r, err := svc2.CreateRack("typed-rack", "", nil, &rt.ID, 0, 0)
+		if err != nil {
+			t.Fatalf("CreateRack with type: %v", err)
+		}
+		if r.HeightU != 24 {
+			t.Errorf("expected HeightU 24 from rack type, got %d", r.HeightU)
+		}
+		if r.PowerCapacityW != 3000 {
+			t.Errorf("expected PowerCapacityW 3000 from rack type, got %d", r.PowerCapacityW)
+		}
+	})
+
+	t.Run("create empty name", func(t *testing.T) {
+		_, err := svc.CreateRack("", "", nil, nil, 42, 0)
+		if !errors.Is(err, models.ErrConstraintViolation) {
+			t.Errorf("expected ErrConstraintViolation, got %v", err)
+		}
+	})
+
+	t.Run("list racks", func(t *testing.T) {
+		svc2, _, _ := newRackSvc()
+		svc2.CreateRack("r1", "", nil, nil, 42, 0)
+		svc2.CreateRack("r2", "", nil, nil, 42, 0)
+		racks, err := svc2.ListRacks(nil)
+		if err != nil {
+			t.Fatalf("ListRacks: %v", err)
+		}
+		if len(racks) != 2 {
+			t.Errorf("expected 2 racks, got %d", len(racks))
+		}
+	})
+}
+
+func TestRackService_PlaceDevice_RUOverflow(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "Cisco", Model: "ASR", HeightU: 2, PowerWatts: 500}
+	rr.nextDeviceID = dmID
+
+	rack, _ := svc.CreateRack("small-rack", "", nil, nil, 2, 10000) // exactly 2U
+
+	// First placement fills the rack.
+	_, err := svc.PlaceDevice(rack.ID, dmID, "dev-1", "", "leaf", 1)
+	if err != nil {
+		t.Fatalf("first PlaceDevice: %v", err)
+	}
+
+	// Second placement should fail: RU overflow (hard reject).
+	_, err = svc.PlaceDevice(rack.ID, dmID, "dev-2", "", "leaf", 0)
+	if !errors.Is(err, models.ErrRUOverflow) {
+		t.Errorf("expected ErrRUOverflow, got %v", err)
+	}
+}
+
+func TestRackService_PlaceDevice_PositionOverlap(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "Arista", Model: "7050", HeightU: 1, PowerWatts: 200}
+	rr.nextDeviceID = dmID
+
+	rack, _ := svc.CreateRack("overlap-rack", "", nil, nil, 10, 5000)
+
+	// Place at position 3.
+	_, err := svc.PlaceDevice(rack.ID, dmID, "dev-a", "", "leaf", 3)
+	if err != nil {
+		t.Fatalf("first place: %v", err)
+	}
+
+	// Attempt to place at position 3 again — overlap.
+	_, err = svc.PlaceDevice(rack.ID, dmID, "dev-b", "", "leaf", 3)
+	if !errors.Is(err, models.ErrPositionOverlap) {
+		t.Errorf("expected ErrPositionOverlap, got %v", err)
+	}
+}
+
+func TestRackService_PlaceDevice_PowerSoftWarning(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	// Device uses 900W; rack capacity is 1000W → 90% > 80% threshold.
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "Juniper", Model: "MX", HeightU: 1, PowerWatts: 900}
+	rr.nextDeviceID = dmID
+
+	rack, _ := svc.CreateRack("power-rack", "", nil, nil, 42, 1000)
+
+	result, err := svc.PlaceDevice(rack.ID, dmID, "dev-power", "", "spine", 1)
+	if err != nil {
+		t.Fatalf("PlaceDevice: %v", err)
+	}
+	// Should succeed with a warning.
+	if result.Warning == "" {
+		t.Error("expected power warning, got empty")
+	}
+}
+
+func TestRackService_PlaceDevice_MultiRU(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "Cisco", Model: "Nexus9500", HeightU: 7, PowerWatts: 3000}
+	rr.nextDeviceID = dmID
+
+	rack, _ := svc.CreateRack("multi-ru-rack", "", nil, nil, 42, 20000)
+
+	result, err := svc.PlaceDevice(rack.ID, dmID, "chassis", "", "spine", 1)
+	if err != nil {
+		t.Fatalf("PlaceDevice multi-RU: %v", err)
+	}
+	if result.Device.Position != 1 {
+		t.Errorf("expected position 1, got %d", result.Device.Position)
+	}
+
+	// Placing at position 2 should overlap with the 7U device at 1.
+	_, err = svc.PlaceDevice(rack.ID, dmID, "overlap-dev", "", "leaf", 2)
+	if !errors.Is(err, models.ErrPositionOverlap) {
+		t.Errorf("expected ErrPositionOverlap for multi-RU overlap, got %v", err)
+	}
+
+	// Placing at position 8 should succeed.
+	_, err = svc.PlaceDevice(rack.ID, dmID, "next-dev", "", "leaf", 8)
+	if err != nil {
+		t.Fatalf("PlaceDevice at 8 after 7U device: %v", err)
+	}
+}
+
+func TestRackService_PlaceDevice_PositionBounds(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "X", Model: "Y", HeightU: 1, PowerWatts: 0}
+	rr.nextDeviceID = dmID
+
+	rack, _ := svc.CreateRack("bounds-rack", "", nil, nil, 5, 0)
+
+	// Position 0 is invalid.
+	_, err := svc.PlaceDevice(rack.ID, dmID, "d", "", "other", -1)
+	if !errors.Is(err, models.ErrConstraintViolation) {
+		t.Errorf("expected ErrConstraintViolation for position -1, got %v", err)
+	}
+
+	// Position beyond rack height.
+	_, err = svc.PlaceDevice(rack.ID, dmID, "d", "", "other", 6)
+	if !errors.Is(err, models.ErrRUOverflow) {
+		t.Errorf("expected ErrRUOverflow for position beyond rack height, got %v", err)
+	}
+}
+
+func TestRackService_PlaceDevice_ExactEndOfRack(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "X", Model: "Y", HeightU: 1, PowerWatts: 0}
+	rr.nextDeviceID = dmID
+
+	rack, _ := svc.CreateRack("exact-end-rack", "", nil, nil, 42, 0)
+
+	// A 1U device placed at position 42 in a 42U rack should succeed (fills last slot exactly).
+	result, err := svc.PlaceDevice(rack.ID, dmID, "last-device", "", "other", 42)
+	if err != nil {
+		t.Fatalf("PlaceDevice at exact end of rack: %v", err)
+	}
+	if result.Device.Position != 42 {
+		t.Errorf("expected position 42, got %d", result.Device.Position)
+	}
+}
+
+func TestRackService_MoveDeviceInRack(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "A", Model: "B", HeightU: 1, PowerWatts: 100}
+	rr.nextDeviceID = dmID
+
+	rack, _ := svc.CreateRack("move-rack", "", nil, nil, 10, 5000)
+	result, _ := svc.PlaceDevice(rack.ID, dmID, "dev", "", "leaf", 1)
+
+	moved, err := svc.MoveDeviceInRack(rack.ID, result.Device.ID, 5)
+	if err != nil {
+		t.Fatalf("MoveDeviceInRack: %v", err)
+	}
+	if moved.Device.Position != 5 {
+		t.Errorf("expected position 5, got %d", moved.Device.Position)
+	}
+}
+
+func TestRackService_MoveDeviceCrossRack(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "A", Model: "B", HeightU: 1, PowerWatts: 100}
+	rr.nextDeviceID = dmID
+
+	src, _ := svc.CreateRack("src-rack", "", nil, nil, 10, 5000)
+	dst, _ := svc.CreateRack("dst-rack", "", nil, nil, 10, 5000)
+
+	placed, _ := svc.PlaceDevice(src.ID, dmID, "dev", "", "leaf", 1)
+
+	result, err := svc.MoveDeviceCrossRack(src.ID, placed.Device.ID, dst.ID, 3)
+	if err != nil {
+		t.Fatalf("MoveDeviceCrossRack: %v", err)
+	}
+	if result.Device.RackID != dst.ID {
+		t.Errorf("expected rack %d, got %d", dst.ID, result.Device.RackID)
+	}
+	if result.Device.Position != 3 {
+		t.Errorf("expected position 3, got %d", result.Device.Position)
+	}
+}
+
+func TestRackService_MoveDeviceCrossRack_RUOverflow(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "A", Model: "B", HeightU: 3, PowerWatts: 100}
+	rr.nextDeviceID = dmID
+
+	src, _ := svc.CreateRack("src", "", nil, nil, 10, 5000)
+	// dst only has 2U available (2U total, filled with nothing but size-3 device can't fit)
+	dst, _ := svc.CreateRack("dst", "", nil, nil, 2, 5000)
+
+	placed, _ := svc.PlaceDevice(src.ID, dmID, "dev", "", "leaf", 1)
+
+	_, err := svc.MoveDeviceCrossRack(src.ID, placed.Device.ID, dst.ID, 0)
+	if !errors.Is(err, models.ErrRUOverflow) {
+		t.Errorf("expected ErrRUOverflow, got %v", err)
+	}
+}
+
+func TestRackService_RemoveDevice(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "A", Model: "B", HeightU: 1, PowerWatts: 100}
+	rr.nextDeviceID = dmID
+
+	rack, _ := svc.CreateRack("rem-rack", "", nil, nil, 10, 5000)
+	placed, _ := svc.PlaceDevice(rack.ID, dmID, "dev", "", "leaf", 1)
+
+	err := svc.RemoveDevice(rack.ID, placed.Device.ID, false)
+	if err != nil {
+		t.Fatalf("RemoveDevice: %v", err)
+	}
+
+	// Removing from wrong rack should fail.
+	placed2, _ := svc.PlaceDevice(rack.ID, dmID, "dev2", "", "leaf", 2)
+	err = svc.RemoveDevice(999, placed2.Device.ID, false)
+	if !errors.Is(err, models.ErrNotFound) {
+		t.Errorf("expected ErrNotFound for wrong rack, got %v", err)
+	}
+}
+
+func TestRackService_GetRackSummary_PowerWarning(t *testing.T) {
+	svc, _, rr := newRackSvc()
+
+	dmID := rr.nextDeviceID + 1
+	rr.deviceModels[dmID] = &models.DeviceModel{ID: dmID, Vendor: "A", Model: "B", HeightU: 1, PowerWatts: 850}
+	rr.nextDeviceID = dmID
+
+	// Rack with 1000W capacity; device uses 850W = 85% → warning.
+	rack, _ := svc.CreateRack("summary-rack", "", nil, nil, 42, 1000)
+	svc.PlaceDevice(rack.ID, dmID, "dev", "", "leaf", 1)
+
+	summary, err := svc.GetRackSummary(rack.ID)
+	if err != nil {
+		t.Fatalf("GetRackSummary: %v", err)
+	}
+	if summary.UsedU != 1 {
+		t.Errorf("expected UsedU 1, got %d", summary.UsedU)
+	}
+	if summary.AvailableU != 41 {
+		t.Errorf("expected AvailableU 41, got %d", summary.AvailableU)
+	}
+	if summary.UsedWatts != 850 {
+		t.Errorf("expected UsedWatts 850, got %d", summary.UsedWatts)
+	}
+	if summary.Warning == "" {
+		t.Error("expected power warning in summary, got empty")
+	}
+}

--- a/server/internal/store/rack_store.go
+++ b/server/internal/store/rack_store.go
@@ -1,0 +1,275 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/rnwolfe/fabrik/server/internal/models"
+)
+
+// RackStore provides CRUD operations for Rack records and device placement.
+type RackStore struct {
+	db *sql.DB
+}
+
+// NewRackStore returns a new RackStore backed by db.
+func NewRackStore(db *sql.DB) *RackStore {
+	return &RackStore{db: db}
+}
+
+// Create inserts a new Rack and returns the saved record.
+func (s *RackStore) Create(r *models.Rack) (*models.Rack, error) {
+	const q = `
+		INSERT INTO racks (block_id, rack_type_id, name, height_u, power_capacity_w, description)
+		VALUES (?, ?, ?, ?, ?, ?)
+		RETURNING id, block_id, rack_type_id, name, height_u, power_capacity_w, description, created_at, updated_at`
+
+	out := &models.Rack{}
+	err := s.db.QueryRow(q, r.BlockID, r.RackTypeID, r.Name, r.HeightU, r.PowerCapacityW, r.Description).
+		Scan(&out.ID, &out.BlockID, &out.RackTypeID, &out.Name, &out.HeightU, &out.PowerCapacityW, &out.Description, &out.CreatedAt, &out.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("create rack: %w", err)
+	}
+	return out, nil
+}
+
+// List returns all Rack records, optionally filtered by block_id.
+func (s *RackStore) List(blockID *int64) ([]*models.Rack, error) {
+	q := `
+		SELECT id, block_id, rack_type_id, name, height_u, power_capacity_w, description, created_at, updated_at
+		FROM racks`
+	args := []any{}
+
+	if blockID != nil {
+		q += " WHERE block_id = ?"
+		args = append(args, *blockID)
+	}
+	q += " ORDER BY id"
+
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list racks: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*models.Rack
+	for rows.Next() {
+		r := &models.Rack{}
+		if err := rows.Scan(&r.ID, &r.BlockID, &r.RackTypeID, &r.Name, &r.HeightU, &r.PowerCapacityW, &r.Description, &r.CreatedAt, &r.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan rack: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate racks: %w", err)
+	}
+	return out, nil
+}
+
+// Get returns the Rack with the given id, or models.ErrNotFound.
+func (s *RackStore) Get(id int64) (*models.Rack, error) {
+	const q = `
+		SELECT id, block_id, rack_type_id, name, height_u, power_capacity_w, description, created_at, updated_at
+		FROM racks
+		WHERE id = ?`
+
+	r := &models.Rack{}
+	err := s.db.QueryRow(q, id).
+		Scan(&r.ID, &r.BlockID, &r.RackTypeID, &r.Name, &r.HeightU, &r.PowerCapacityW, &r.Description, &r.CreatedAt, &r.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get rack %d: %w", id, err)
+	}
+	return r, nil
+}
+
+// Update modifies the Rack with the given id and returns the updated record.
+func (s *RackStore) Update(r *models.Rack) (*models.Rack, error) {
+	const q = `
+		UPDATE racks
+		SET block_id = ?, name = ?, description = ?,
+		    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+		WHERE id = ?
+		RETURNING id, block_id, rack_type_id, name, height_u, power_capacity_w, description, created_at, updated_at`
+
+	out := &models.Rack{}
+	err := s.db.QueryRow(q, r.BlockID, r.Name, r.Description, r.ID).
+		Scan(&out.ID, &out.BlockID, &out.RackTypeID, &out.Name, &out.HeightU, &out.PowerCapacityW, &out.Description, &out.CreatedAt, &out.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("update rack %d: %w", r.ID, err)
+	}
+	return out, nil
+}
+
+// Delete removes the Rack with the given id and cascades to devices.
+func (s *RackStore) Delete(id int64) error {
+	result, err := s.db.Exec(`DELETE FROM racks WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete rack %d: %w", id, err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete rack rows affected: %w", err)
+	}
+	if n == 0 {
+		return models.ErrNotFound
+	}
+	return nil
+}
+
+// PlaceDevice inserts a device into a rack at the given position.
+func (s *RackStore) PlaceDevice(d *models.Device) (*models.Device, error) {
+	const q = `
+		INSERT INTO devices (rack_id, device_model_id, name, role, position, description)
+		VALUES (?, ?, ?, ?, ?, ?)
+		RETURNING id, rack_id, device_model_id, name, role, position, description, created_at, updated_at`
+
+	out := &models.Device{}
+	err := s.db.QueryRow(q, d.RackID, d.DeviceModelID, d.Name, d.Role, d.Position, d.Description).
+		Scan(&out.ID, &out.RackID, &out.DeviceModelID, &out.Name, &out.Role, &out.Position, &out.Description, &out.CreatedAt, &out.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("place device: %w", err)
+	}
+	return out, nil
+}
+
+// GetDevice returns the device with the given id, or models.ErrNotFound.
+func (s *RackStore) GetDevice(id int64) (*models.Device, error) {
+	const q = `
+		SELECT id, rack_id, device_model_id, name, role, position, description, created_at, updated_at
+		FROM devices
+		WHERE id = ?`
+
+	d := &models.Device{}
+	err := s.db.QueryRow(q, id).
+		Scan(&d.ID, &d.RackID, &d.DeviceModelID, &d.Name, &d.Role, &d.Position, &d.Description, &d.CreatedAt, &d.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get device %d: %w", id, err)
+	}
+	return d, nil
+}
+
+// MoveDevice updates a device's rack and position.
+func (s *RackStore) MoveDevice(deviceID, rackID int64, position int) (*models.Device, error) {
+	const q = `
+		UPDATE devices
+		SET rack_id = ?, position = ?,
+		    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+		WHERE id = ?
+		RETURNING id, rack_id, device_model_id, name, role, position, description, created_at, updated_at`
+
+	d := &models.Device{}
+	err := s.db.QueryRow(q, rackID, position, deviceID).
+		Scan(&d.ID, &d.RackID, &d.DeviceModelID, &d.Name, &d.Role, &d.Position, &d.Description, &d.CreatedAt, &d.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("move device %d: %w", deviceID, err)
+	}
+	return d, nil
+}
+
+// RemoveDevice deletes a device. If compact is true, devices above the gap are shifted down.
+func (s *RackStore) RemoveDevice(deviceID int64, compact bool) error {
+	// Load the device first to know its position and height.
+	device, err := s.GetDevice(deviceID)
+	if err != nil {
+		return err
+	}
+
+	// Get model height.
+	var heightU int
+	if err := s.db.QueryRow(`SELECT height_u FROM device_models WHERE id = ?`, device.DeviceModelID).Scan(&heightU); err != nil {
+		// Default to 1 if model not found.
+		heightU = 1
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.Exec(`DELETE FROM devices WHERE id = ?`, deviceID); err != nil {
+		return fmt.Errorf("delete device %d: %w", deviceID, err)
+	}
+
+	if compact {
+		// Shift all devices above the deleted device's position down by heightU.
+		_, err = tx.Exec(`
+			UPDATE devices
+			SET position = position - ?,
+			    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+			WHERE rack_id = ? AND position > ?`,
+			heightU, device.RackID, device.Position)
+		if err != nil {
+			return fmt.Errorf("compact devices: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// ListDevicesInRack returns all devices in a rack with model info.
+func (s *RackStore) ListDevicesInRack(rackID int64) ([]*models.DeviceSummary, error) {
+	const q = `
+		SELECT d.id, d.rack_id, d.device_model_id, d.name, d.role, d.position, d.description, d.created_at, d.updated_at,
+		       dm.vendor, dm.model, dm.height_u, dm.power_watts
+		FROM devices d
+		JOIN device_models dm ON d.device_model_id = dm.id
+		WHERE d.rack_id = ?
+		ORDER BY d.position`
+
+	rows, err := s.db.Query(q, rackID)
+	if err != nil {
+		return nil, fmt.Errorf("list devices in rack %d: %w", rackID, err)
+	}
+	defer rows.Close()
+
+	var out []*models.DeviceSummary
+	for rows.Next() {
+		ds := &models.DeviceSummary{}
+		if err := rows.Scan(
+			&ds.Device.ID, &ds.Device.RackID, &ds.Device.DeviceModelID,
+			&ds.Device.Name, &ds.Device.Role, &ds.Device.Position, &ds.Device.Description,
+			&ds.Device.CreatedAt, &ds.Device.UpdatedAt,
+			&ds.ModelVendor, &ds.ModelName, &ds.HeightU, &ds.PowerWatts,
+		); err != nil {
+			return nil, fmt.Errorf("scan device summary: %w", err)
+		}
+		out = append(out, ds)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate devices: %w", err)
+	}
+	return out, nil
+}
+
+// GetDeviceModel returns the DeviceModel with the given id.
+func (s *RackStore) GetDeviceModel(id int64) (*models.DeviceModel, error) {
+	const q = `
+		SELECT id, vendor, model, port_count, height_u, power_watts, description, created_at, updated_at
+		FROM device_models
+		WHERE id = ?`
+
+	dm := &models.DeviceModel{}
+	err := s.db.QueryRow(q, id).
+		Scan(&dm.ID, &dm.Vendor, &dm.Model, &dm.PortCount, &dm.HeightU, &dm.PowerWatts, &dm.Description, &dm.CreatedAt, &dm.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get device model %d: %w", id, err)
+	}
+	return dm, nil
+}

--- a/server/internal/store/rack_store_test.go
+++ b/server/internal/store/rack_store_test.go
@@ -1,0 +1,297 @@
+package store_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rnwolfe/fabrik/server/internal/models"
+	"github.com/rnwolfe/fabrik/server/internal/store"
+)
+
+func TestRackTypeStore_CRUD(t *testing.T) {
+	db := openTestDB(t)
+	s := store.NewRackTypeStore(db)
+
+	t.Run("create", func(t *testing.T) {
+		rt, err := s.Create(&models.RackTemplate{Name: "42U-std", HeightU: 42, PowerCapacityW: 10000})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if rt.ID == 0 {
+			t.Error("expected non-zero ID")
+		}
+		if rt.Name != "42U-std" {
+			t.Errorf("expected name %q, got %q", "42U-std", rt.Name)
+		}
+		if rt.HeightU != 42 {
+			t.Errorf("expected HeightU 42, got %d", rt.HeightU)
+		}
+		if rt.PowerCapacityW != 10000 {
+			t.Errorf("expected PowerCapacityW 10000, got %d", rt.PowerCapacityW)
+		}
+		if rt.CreatedAt.IsZero() {
+			t.Error("expected non-zero CreatedAt")
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		s.Create(&models.RackTemplate{Name: "list-type-1", HeightU: 24})
+		s.Create(&models.RackTemplate{Name: "list-type-2", HeightU: 48})
+		rts, err := s.List()
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(rts) < 2 {
+			t.Errorf("expected at least 2 rack types, got %d", len(rts))
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		created, _ := s.Create(&models.RackTemplate{Name: "get-type", HeightU: 42})
+		got, err := s.Get(created.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.ID != created.ID {
+			t.Errorf("expected ID %d, got %d", created.ID, got.ID)
+		}
+	})
+
+	t.Run("get not found", func(t *testing.T) {
+		_, err := s.Get(999999)
+		if !errors.Is(err, models.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		created, _ := s.Create(&models.RackTemplate{Name: "update-type", HeightU: 42, PowerCapacityW: 5000})
+		updated, err := s.Update(&models.RackTemplate{
+			ID:             created.ID,
+			Name:           "update-type-v2",
+			HeightU:        48,
+			PowerCapacityW: 8000,
+		})
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if updated.Name != "update-type-v2" {
+			t.Errorf("expected name %q, got %q", "update-type-v2", updated.Name)
+		}
+		if updated.HeightU != 48 {
+			t.Errorf("expected HeightU 48, got %d", updated.HeightU)
+		}
+	})
+
+	t.Run("update not found", func(t *testing.T) {
+		_, err := s.Update(&models.RackTemplate{ID: 999999, Name: "x", HeightU: 42})
+		if !errors.Is(err, models.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		created, _ := s.Create(&models.RackTemplate{Name: "delete-type", HeightU: 42})
+		if err := s.Delete(created.ID); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		_, err := s.Get(created.ID)
+		if !errors.Is(err, models.ErrNotFound) {
+			t.Errorf("expected ErrNotFound after delete, got %v", err)
+		}
+	})
+
+	t.Run("delete not found", func(t *testing.T) {
+		err := s.Delete(999999)
+		if !errors.Is(err, models.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+}
+
+func TestRackStore_CRUD(t *testing.T) {
+	db := openTestDB(t)
+	s := store.NewRackStore(db)
+
+	t.Run("create standalone rack", func(t *testing.T) {
+		r, err := s.Create(&models.Rack{Name: "rack-01", HeightU: 42, PowerCapacityW: 10000})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if r.ID == 0 {
+			t.Error("expected non-zero ID")
+		}
+		if r.Name != "rack-01" {
+			t.Errorf("expected name %q, got %q", "rack-01", r.Name)
+		}
+		if r.BlockID != nil {
+			t.Errorf("expected nil BlockID, got %v", r.BlockID)
+		}
+	})
+
+	t.Run("list all", func(t *testing.T) {
+		s.Create(&models.Rack{Name: "list-rack-1", HeightU: 42})
+		s.Create(&models.Rack{Name: "list-rack-2", HeightU: 42})
+		racks, err := s.List(nil)
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(racks) < 2 {
+			t.Errorf("expected at least 2 racks, got %d", len(racks))
+		}
+	})
+
+	t.Run("get", func(t *testing.T) {
+		created, _ := s.Create(&models.Rack{Name: "get-rack", HeightU: 42})
+		got, err := s.Get(created.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.ID != created.ID {
+			t.Errorf("expected ID %d, got %d", created.ID, got.ID)
+		}
+	})
+
+	t.Run("get not found", func(t *testing.T) {
+		_, err := s.Get(999999)
+		if !errors.Is(err, models.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		created, _ := s.Create(&models.Rack{Name: "upd-rack", HeightU: 42})
+		updated, err := s.Update(&models.Rack{ID: created.ID, Name: "upd-rack-v2", Description: "updated"})
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if updated.Name != "upd-rack-v2" {
+			t.Errorf("expected name %q, got %q", "upd-rack-v2", updated.Name)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		created, _ := s.Create(&models.Rack{Name: "del-rack", HeightU: 42})
+		if err := s.Delete(created.ID); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		_, err := s.Get(created.ID)
+		if !errors.Is(err, models.ErrNotFound) {
+			t.Errorf("expected ErrNotFound after delete, got %v", err)
+		}
+	})
+
+	t.Run("delete not found", func(t *testing.T) {
+		err := s.Delete(999999)
+		if !errors.Is(err, models.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+}
+
+func TestRackStore_DevicePlacement(t *testing.T) {
+	db := openTestDB(t)
+	s := store.NewRackStore(db)
+
+	// Seed a device model.
+	var dmID int64
+	err := db.QueryRow(`
+		INSERT INTO device_models (vendor, model, port_count, height_u, power_watts)
+		VALUES ('Cisco', 'ASR9000', 32, 2, 500)
+		RETURNING id`).Scan(&dmID)
+	if err != nil {
+		t.Fatalf("seed device model: %v", err)
+	}
+
+	rack, err := s.Create(&models.Rack{Name: "test-rack", HeightU: 42, PowerCapacityW: 5000})
+	if err != nil {
+		t.Fatalf("create rack: %v", err)
+	}
+
+	t.Run("place device", func(t *testing.T) {
+		d, err := s.PlaceDevice(&models.Device{
+			RackID:        rack.ID,
+			DeviceModelID: dmID,
+			Name:          "device-1",
+			Role:          models.DeviceRoleLeaf,
+			Position:      1,
+		})
+		if err != nil {
+			t.Fatalf("PlaceDevice: %v", err)
+		}
+		if d.ID == 0 {
+			t.Error("expected non-zero device ID")
+		}
+		if d.Position != 1 {
+			t.Errorf("expected position 1, got %d", d.Position)
+		}
+	})
+
+	t.Run("list devices in rack", func(t *testing.T) {
+		devices, err := s.ListDevicesInRack(rack.ID)
+		if err != nil {
+			t.Fatalf("ListDevicesInRack: %v", err)
+		}
+		if len(devices) == 0 {
+			t.Error("expected at least one device")
+		}
+		// Verify model info is populated.
+		if devices[0].ModelVendor == "" {
+			t.Error("expected non-empty ModelVendor")
+		}
+		if devices[0].HeightU == 0 {
+			t.Error("expected non-zero HeightU in summary")
+		}
+	})
+
+	t.Run("move device", func(t *testing.T) {
+		d, _ := s.PlaceDevice(&models.Device{
+			RackID:        rack.ID,
+			DeviceModelID: dmID,
+			Name:          "device-move",
+			Role:          models.DeviceRoleLeaf,
+			Position:      5,
+		})
+		moved, err := s.MoveDevice(d.ID, rack.ID, 10)
+		if err != nil {
+			t.Fatalf("MoveDevice: %v", err)
+		}
+		if moved.Position != 10 {
+			t.Errorf("expected position 10, got %d", moved.Position)
+		}
+	})
+
+	t.Run("remove device no compact", func(t *testing.T) {
+		d, _ := s.PlaceDevice(&models.Device{
+			RackID:        rack.ID,
+			DeviceModelID: dmID,
+			Name:          "device-remove",
+			Role:          models.DeviceRoleLeaf,
+			Position:      20,
+		})
+		if err := s.RemoveDevice(d.ID, false); err != nil {
+			t.Fatalf("RemoveDevice: %v", err)
+		}
+		_, err := s.GetDevice(d.ID)
+		if !errors.Is(err, models.ErrNotFound) {
+			t.Errorf("expected ErrNotFound after remove, got %v", err)
+		}
+	})
+
+	t.Run("get device model", func(t *testing.T) {
+		dm, err := s.GetDeviceModel(dmID)
+		if err != nil {
+			t.Fatalf("GetDeviceModel: %v", err)
+		}
+		if dm.Vendor != "Cisco" {
+			t.Errorf("expected vendor Cisco, got %s", dm.Vendor)
+		}
+	})
+
+	t.Run("get device model not found", func(t *testing.T) {
+		_, err := s.GetDeviceModel(999999)
+		if !errors.Is(err, models.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+}

--- a/server/internal/store/rack_type_store.go
+++ b/server/internal/store/rack_type_store.go
@@ -1,0 +1,148 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/rnwolfe/fabrik/server/internal/models"
+)
+
+// RackTypeStore provides CRUD operations for RackTemplate records.
+type RackTypeStore struct {
+	db *sql.DB
+}
+
+// NewRackTypeStore returns a new RackTypeStore backed by db.
+func NewRackTypeStore(db *sql.DB) *RackTypeStore {
+	return &RackTypeStore{db: db}
+}
+
+// Create inserts a new RackTemplate and returns the saved record.
+func (s *RackTypeStore) Create(rt *models.RackTemplate) (*models.RackTemplate, error) {
+	const q = `
+		INSERT INTO rack_types (name, height_u, power_capacity_w, description)
+		VALUES (?, ?, ?, ?)
+		RETURNING id, name, height_u, power_capacity_w, description, created_at, updated_at`
+
+	out := &models.RackTemplate{}
+	err := s.db.QueryRow(q, rt.Name, rt.HeightU, rt.PowerCapacityW, rt.Description).
+		Scan(&out.ID, &out.Name, &out.HeightU, &out.PowerCapacityW, &out.Description, &out.CreatedAt, &out.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("create rack type: %w", err)
+	}
+	return out, nil
+}
+
+// List returns all RackTemplate records ordered by id.
+func (s *RackTypeStore) List() ([]*models.RackTemplate, error) {
+	const q = `
+		SELECT id, name, height_u, power_capacity_w, description, created_at, updated_at
+		FROM rack_types
+		ORDER BY id`
+
+	rows, err := s.db.Query(q)
+	if err != nil {
+		return nil, fmt.Errorf("list rack types: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*models.RackTemplate
+	for rows.Next() {
+		rt := &models.RackTemplate{}
+		if err := rows.Scan(&rt.ID, &rt.Name, &rt.HeightU, &rt.PowerCapacityW, &rt.Description, &rt.CreatedAt, &rt.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan rack type: %w", err)
+		}
+		out = append(out, rt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rack types: %w", err)
+	}
+	return out, nil
+}
+
+// Get returns the RackTemplate with the given id, or models.ErrNotFound.
+func (s *RackTypeStore) Get(id int64) (*models.RackTemplate, error) {
+	const q = `
+		SELECT id, name, height_u, power_capacity_w, description, created_at, updated_at
+		FROM rack_types
+		WHERE id = ?`
+
+	rt := &models.RackTemplate{}
+	err := s.db.QueryRow(q, id).
+		Scan(&rt.ID, &rt.Name, &rt.HeightU, &rt.PowerCapacityW, &rt.Description, &rt.CreatedAt, &rt.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get rack type %d: %w", id, err)
+	}
+	return rt, nil
+}
+
+// Update modifies the RackTemplate with the given id and returns the updated record.
+func (s *RackTypeStore) Update(rt *models.RackTemplate) (*models.RackTemplate, error) {
+	const q = `
+		UPDATE rack_types
+		SET name = ?, height_u = ?, power_capacity_w = ?, description = ?,
+		    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+		WHERE id = ?
+		RETURNING id, name, height_u, power_capacity_w, description, created_at, updated_at`
+
+	out := &models.RackTemplate{}
+	err := s.db.QueryRow(q, rt.Name, rt.HeightU, rt.PowerCapacityW, rt.Description, rt.ID).
+		Scan(&out.ID, &out.Name, &out.HeightU, &out.PowerCapacityW, &out.Description, &out.CreatedAt, &out.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("update rack type %d: %w", rt.ID, err)
+	}
+	return out, nil
+}
+
+// Delete removes the RackTemplate with the given id.
+// Returns models.ErrNotFound if it does not exist.
+// Returns models.ErrConflict if racks reference this rack type.
+func (s *RackTypeStore) Delete(id int64) error {
+	// Check for referencing racks.
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM racks WHERE rack_type_id = ?`, id).Scan(&count); err != nil {
+		return fmt.Errorf("check rack type references: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf("%w: %d rack(s) reference this rack type", models.ErrConflict, count)
+	}
+
+	result, err := s.db.Exec(`DELETE FROM rack_types WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete rack type %d: %w", id, err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete rack type rows affected: %w", err)
+	}
+	if n == 0 {
+		return models.ErrNotFound
+	}
+	return nil
+}
+
+// ListRackIDsForType returns the IDs of all racks referencing the given rack type.
+func (s *RackTypeStore) ListRackIDsForType(typeID int64) ([]int64, error) {
+	rows, err := s.db.Query(`SELECT id FROM racks WHERE rack_type_id = ?`, typeID)
+	if err != nil {
+		return nil, fmt.Errorf("list rack ids for type %d: %w", typeID, err)
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan rack id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}


### PR DESCRIPTION
## Summary

- Implements rack type templates (CRUD at `/api/rack-types`) for reusable rack specs
- Implements rack instances (CRUD at `/api/racks`) with optional block assignment and rack type inheritance
- Implements device placement with hard RU overflow rejection and soft power budget warnings
- Adds cross-rack device moves, compact removal mode, and position overlap detection
- Adds rack management UI at `/racks` in the Angular frontend with the `RackListComponent`
- Adds knowledge base article at `docs/knowledge/infrastructure/rack-modeling.md`

## Acceptance Criteria

- [x] Rack type CRUD — `POST/GET/PUT/DELETE /api/rack-types` with 409 on delete if racks reference it
- [x] Rack instance CRUD — `POST/GET/PUT/DELETE /api/racks` with optional `?block_id=` filter
- [x] Device placement — `POST /api/racks/:id/devices` with auto-suggest position when omitted
- [x] RU overflow hard reject — 400 if device doesn't fit or position overflows rack height
- [x] Position overlap hard reject — 400 if placement overlaps existing device
- [x] Power budget soft warning — `warning` field in response when >80% utilization or oversubscribed
- [x] Rack summary — `GET /api/racks/:id` returns used/available RU, used watts, device list, and warning
- [x] Device removal — `DELETE /api/racks/:rack_id/devices/:device_id?compact=true|false`
- [x] Cross-rack moves — `PUT /api/racks/:rack_id/devices/:device_id/move` with constraint validation
- [x] Migration 0002 — adds `rack_types` table, makes `block_id` nullable, adds `rack_type_id` and `power_capacity_w` to `racks`
- [x] All Go unit tests pass (store, service, handler layers)
- [x] All Angular unit tests pass (service HTTP calls, component behavior)
- [x] Build passes, lint passes

Closes #3