### PR TITLE
feat: add Clos-shaped templates to new-design dialog

### DIFF
--- a/docs/knowledge/dashboard.md
+++ b/docs/knowledge/dashboard.md
@@ -1,0 +1,102 @@
+---
+title: "Dashboard & Design Templates"
+category: "getting-started"
+tags: [dashboard, templates, clos, design]
+---
+
+# Dashboard & Design Templates
+
+The fabrik dashboard is your home screen. From here you can create and open
+designs, browse the hardware catalog, and access the metrics and knowledge base.
+
+## Creating a Design
+
+Click **New Design** to open the creation dialog. Give your design a name and
+an optional description, then choose a starting template.
+
+## Design Templates
+
+Templates scaffold an initial site → superblock → block hierarchy so you can
+start configuring a realistic topology immediately. Every template creates
+**named** hierarchy objects (e.g. "Site 1", "Pod A") and does **not**
+pre-assign any leaf or spine device models — those are set per-block after
+creation.
+
+### Blank
+
+No hierarchy is created. You get an empty canvas and can add sites, pods
+(super-blocks), and blocks manually. This is equivalent to the original
+behavior before templates were introduced.
+
+**When to use:** You have a bespoke topology in mind, or you want full control
+over every naming and structural decision from the start.
+
+### 2-stage Clos
+
+Creates the simplest production-grade Clos topology:
+
+```
+Site 1
+└── Pod A
+    └── Block 1   (leaf–spine fabric)
+```
+
+A 2-stage Clos is a single-tier spine layer connecting all leaves. It is
+the most common design for a single-pod, single-plane datacenter.
+
+**When to use:** One pod, one failure domain, moderate scale.
+
+### 3-stage Clos
+
+Creates the same structural skeleton as a 2-stage Clos but signals that a
+super-spine (aggregation) tier will be configured at the superblock level:
+
+```
+Site 1
+└── Pod A  (super-spine aggregation pod)
+    └── Block 1
+```
+
+After creation, assign aggregation models to the Pod to introduce the
+super-spine tier and connect multiple blocks through it.
+
+**When to use:** You need to scale beyond a single leaf–spine plane, or you
+anticipate adding more blocks that must communicate at low latency within
+the pod.
+
+### Pod-based fabric
+
+Creates a multi-pod topology with two independent pods and four blocks total:
+
+```
+Site 1
+├── Pod A
+│   ├── Block 1
+│   └── Block 2
+└── Pod B
+    ├── Block 3
+    └── Block 4
+```
+
+Each pod is an isolated failure domain. Pods can be interconnected via
+DCI or a separate super-spine layer later.
+
+**When to use:** Large-scale datacenters where fault isolation between
+pods is a first-class requirement.
+
+## Partial Scaffold Failures
+
+If a template scaffold fails partway through (for example, the API is
+unreachable), fabrik will:
+
+1. Navigate you to the design view with whatever hierarchy was successfully
+   created.
+2. Show a non-blocking notification describing the partial failure.
+
+You can manually add the missing hierarchy objects from the design view.
+
+## Related Topics
+
+- [Design Hierarchy](hierarchy.md) — the five-level site → block model
+- [Clos Topology](networking/clos-topology.md) — Clos fabric fundamentals
+- [Block Aggregation](block-aggregation.md) — assigning spine/leaf models to blocks

--- a/frontend/e2e/design-templates.spec.ts
+++ b/frontend/e2e/design-templates.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * E2E tests for design templates (issue #50).
+ *
+ * These tests require a running fabrik backend with a clean test database.
+ * Run with: npx playwright test
+ *
+ * The base URL is configured via the PLAYWRIGHT_BASE_URL environment variable
+ * (default: http://localhost:4200).
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:4200';
+
+test.describe('New Design dialog — templates', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE_URL);
+  });
+
+  test('shows 4 template options when dialog opens', async ({ page }) => {
+    await page.getByRole('button', { name: /new design/i }).click();
+    await expect(page.getByText('Start from template')).toBeVisible();
+    await expect(page.getByRole('button', { name: /blank/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /2-stage clos/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /3-stage clos/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /pod-based fabric/i })).toBeVisible();
+  });
+
+  test('Blank is selected by default', async ({ page }) => {
+    await page.getByRole('button', { name: /new design/i }).click();
+    const blankBtn = page.getByRole('button', { name: /blank/i });
+    await expect(blankBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('2-stage Clos: block exists in hierarchy after creation', async ({ page }) => {
+    await page.getByRole('button', { name: /new design/i }).click();
+
+    // Select 2-stage Clos template
+    await page.getByRole('button', { name: /2-stage clos/i }).click();
+    await expect(page.getByRole('button', { name: /2-stage clos/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    // Fill name and submit
+    await page.getByLabel(/name/i).fill('E2E 2-stage test');
+    await page.getByRole('button', { name: /create design/i }).click();
+
+    // Should navigate to /design
+    await page.waitForURL('**/design');
+
+    // Hierarchy tree should contain Block 1
+    await expect(page.getByText('Block 1')).toBeVisible({ timeout: 10_000 });
+    // And the site and pod should also be visible
+    await expect(page.getByText('Site 1')).toBeVisible();
+    await expect(page.getByText('Pod A')).toBeVisible();
+  });
+
+  test('Blank: no hierarchy is created — hierarchy section is empty', async ({ page }) => {
+    await page.getByRole('button', { name: /new design/i }).click();
+
+    // Blank is default — no need to click
+    await page.getByLabel(/name/i).fill('E2E blank test');
+    await page.getByRole('button', { name: /create design/i }).click();
+
+    await page.waitForURL('**/design');
+
+    // No "Site 1" should appear (blank canvas)
+    await expect(page.getByText('Site 1')).not.toBeVisible();
+    await expect(page.getByText('Pod A')).not.toBeVisible();
+    await expect(page.getByText('Block 1')).not.toBeVisible();
+  });
+
+  test('pod-based fabric: 4 blocks exist after creation', async ({ page }) => {
+    await page.getByRole('button', { name: /new design/i }).click();
+
+    await page.getByRole('button', { name: /pod-based fabric/i }).click();
+    await page.getByLabel(/name/i).fill('E2E pod-based test');
+    await page.getByRole('button', { name: /create design/i }).click();
+
+    await page.waitForURL('**/design');
+
+    // All four blocks should appear in the hierarchy
+    await expect(page.getByText('Block 1')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Block 2')).toBeVisible();
+    await expect(page.getByText('Block 3')).toBeVisible();
+    await expect(page.getByText('Block 4')).toBeVisible();
+    await expect(page.getByText('Pod A')).toBeVisible();
+    await expect(page.getByText('Pod B')).toBeVisible();
+  });
+});

--- a/frontend/src/features/dashboard/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.test.tsx
@@ -1,0 +1,236 @@
+/// <reference types="vitest/globals" />
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { DesignProvider } from '@/contexts/DesignContext';
+import DashboardPage from './DashboardPage';
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockDesignsCreate = vi.fn();
+const mockDesignsList = vi.fn(() => Promise.resolve([]));
+
+vi.mock('@/api/designs', () => ({
+  designsApi: {
+    list: () => mockDesignsList(),
+    create: (...args: unknown[]) => mockDesignsCreate(...args),
+  },
+}));
+
+const mockBlankScaffold = vi.fn((_designId: number) => Promise.resolve());
+const mockTwoStageScaffold = vi.fn((_designId: number) => Promise.resolve());
+
+vi.mock('./designTemplates', () => ({
+  DESIGN_TEMPLATES: [
+    {
+      id: 'blank',
+      name: 'Blank',
+      description: 'Start with an empty canvas.',
+      scaffold: (designId: number) => mockBlankScaffold(designId),
+    },
+    {
+      id: '2-stage-clos',
+      name: '2-stage Clos',
+      description: 'Single pod with one leaf–spine block.',
+      scaffold: (designId: number) => mockTwoStageScaffold(designId),
+    },
+    {
+      id: '3-stage-clos',
+      name: '3-stage Clos',
+      description: 'Single pod with super-spine tier.',
+      scaffold: vi.fn(() => Promise.resolve()),
+    },
+    {
+      id: 'pod-based',
+      name: 'Pod-based fabric',
+      description: 'Two independent pods.',
+      scaffold: vi.fn(() => Promise.resolve()),
+    },
+  ],
+}));
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter>
+        <QueryClientProvider client={client}>
+          <DesignProvider>{children}</DesignProvider>
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+  };
+}
+
+async function openDialog() {
+  const btn = screen.getByRole('button', { name: /new design/i });
+  fireEvent.click(btn);
+  // Wait for the dialog to appear
+  await waitFor(() => screen.getByRole('dialog'));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  mockDesignsList.mockResolvedValue([]);
+});
+
+// ── Template visibility ───────────────────────────────────────────────────────
+
+describe('New Design dialog — template section visible on open', () => {
+  it('shows "Start from template" label when dialog opens', async () => {
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await openDialog();
+    expect(screen.getByText('Start from template')).toBeInTheDocument();
+  });
+
+  it('shows all 4 template options', async () => {
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await openDialog();
+    expect(screen.getByText('Blank')).toBeInTheDocument();
+    expect(screen.getByText('2-stage Clos')).toBeInTheDocument();
+    expect(screen.getByText('3-stage Clos')).toBeInTheDocument();
+    expect(screen.getByText('Pod-based fabric')).toBeInTheDocument();
+  });
+
+  it('Blank template is selected by default (aria-pressed=true)', async () => {
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await openDialog();
+    const blankBtn = screen.getByRole('button', { name: /blank/i });
+    expect(blankBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('non-blank templates are not selected by default', async () => {
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await openDialog();
+    const twoStageBtn = screen.getByRole('button', { name: /2-stage clos/i });
+    expect(twoStageBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+});
+
+// ── Blank template — no scaffold ─────────────────────────────────────────────
+
+describe('Blank template', () => {
+  it('does not call scaffold when Blank is selected and form submitted', async () => {
+    const createdDesign = { id: 99, name: 'My Design', description: '', created_at: '', updated_at: '' };
+    mockDesignsCreate.mockResolvedValue(createdDesign);
+
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await openDialog();
+
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'My Design' } });
+    fireEvent.click(screen.getByRole('button', { name: /create design/i }));
+
+    await waitFor(() => expect(mockDesignsCreate).toHaveBeenCalledTimes(1));
+    expect(mockBlankScaffold).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/design');
+  });
+});
+
+// ── Non-blank template — scaffold is called ───────────────────────────────────
+
+describe('Non-blank template', () => {
+  it('calls scaffold for the selected template after design creation', async () => {
+    const createdDesign = { id: 55, name: 'Test', description: '', created_at: '', updated_at: '' };
+    mockDesignsCreate.mockResolvedValue(createdDesign);
+
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await openDialog();
+
+    // Select 2-stage Clos
+    const twoStageBtn = screen.getByRole('button', { name: /2-stage clos/i });
+    fireEvent.click(twoStageBtn);
+    expect(twoStageBtn).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Test' } });
+    fireEvent.click(screen.getByRole('button', { name: /create design/i }));
+
+    await waitFor(() => expect(mockTwoStageScaffold).toHaveBeenCalledWith(55));
+    expect(mockNavigate).toHaveBeenCalledWith('/design');
+  });
+
+  it('navigates to /design even when scaffold throws (partial failure)', async () => {
+    const createdDesign = { id: 66, name: 'Partial', description: '', created_at: '', updated_at: '' };
+    mockDesignsCreate.mockResolvedValue(createdDesign);
+    mockTwoStageScaffold.mockRejectedValue(new Error('API error'));
+
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await openDialog();
+
+    fireEvent.click(screen.getByRole('button', { name: /2-stage clos/i }));
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Partial' } });
+    fireEvent.click(screen.getByRole('button', { name: /create design/i }));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/design'));
+  });
+
+  it('shows a toast when scaffold fails', async () => {
+    const createdDesign = { id: 77, name: 'Toast', description: '', created_at: '', updated_at: '' };
+    mockDesignsCreate.mockResolvedValue(createdDesign);
+    mockTwoStageScaffold.mockRejectedValue(new Error('some API error'));
+
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await openDialog();
+
+    fireEvent.click(screen.getByRole('button', { name: /2-stage clos/i }));
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Toast' } });
+    fireEvent.click(screen.getByRole('button', { name: /create design/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('status').textContent).toContain('Template partially applied');
+  });
+
+  it('blank scaffold is never called even when another template is selected', async () => {
+    const createdDesign = { id: 88, name: 'NoBlank', description: '', created_at: '', updated_at: '' };
+    mockDesignsCreate.mockResolvedValue(createdDesign);
+
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await openDialog();
+
+    fireEvent.click(screen.getByRole('button', { name: /2-stage clos/i }));
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'NoBlank' } });
+    fireEvent.click(screen.getByRole('button', { name: /create design/i }));
+
+    await waitFor(() => expect(mockTwoStageScaffold).toHaveBeenCalled());
+    expect(mockBlankScaffold).not.toHaveBeenCalled();
+  });
+});
+
+// ── Dialog reset ─────────────────────────────────────────────────────────────
+
+describe('Dialog reset on close', () => {
+  it('resets template selection to Blank when dialog is closed and re-opened', async () => {
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await openDialog();
+
+    // Select non-blank template
+    fireEvent.click(screen.getByRole('button', { name: /2-stage clos/i }));
+    expect(screen.getByRole('button', { name: /2-stage clos/i })).toHaveAttribute('aria-pressed', 'true');
+
+    // Close dialog
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    // Re-open
+    await openDialog();
+    expect(screen.getByRole('button', { name: /blank/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /2-stage clos/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -13,6 +13,7 @@ import {
   FolderOpen,
   ArrowRight,
   Database,
+  Check,
 } from 'lucide-react';
 import { designsApi } from '@/api/designs';
 import { useDesign } from '@/contexts/DesignContext';
@@ -24,7 +25,9 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
+import { DESIGN_TEMPLATES } from './designTemplates';
 import type { Design } from '@/models';
+import { cn } from '@/lib/utils';
 
 const createDesignSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100),
@@ -35,6 +38,8 @@ type CreateDesignForm = z.infer<typeof createDesignSchema>;
 
 export default function DashboardPage() {
   const [createOpen, setCreateOpen] = useState(false);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string>('blank');
+  const [scaffoldToast, setScaffoldToast] = useState<string | null>(null);
   const { setActiveDesignId, activeDesignId } = useDesign();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -46,11 +51,29 @@ export default function DashboardPage() {
 
   const createMutation = useMutation({
     mutationFn: designsApi.create,
-    onSuccess: (design) => {
+    onSuccess: async (design) => {
       queryClient.invalidateQueries({ queryKey: ['designs'] });
       setActiveDesignId(design.id);
       setCreateOpen(false);
       reset();
+
+      const template = DESIGN_TEMPLATES.find((t) => t.id === selectedTemplateId);
+      if (template && template.id !== 'blank') {
+        try {
+          await template.scaffold(design.id);
+          // Invalidate hierarchy queries so the design view shows fresh data
+          queryClient.invalidateQueries({ queryKey: ['hierarchy'] });
+        } catch (err) {
+          // Non-blocking: surface error as toast, still land on design view
+          const msg =
+            err instanceof Error
+              ? err.message
+              : 'Some scaffold steps failed. Your design was created with partial hierarchy.';
+          setScaffoldToast(`Template partially applied: ${msg}`);
+        }
+      }
+
+      navigate('/design');
     },
   });
 
@@ -70,6 +93,14 @@ export default function DashboardPage() {
   const handleOpenDesign = (design: Design) => {
     setActiveDesignId(design.id);
     navigate('/design');
+  };
+
+  const handleDialogClose = (open: boolean) => {
+    if (!open) {
+      setSelectedTemplateId('blank');
+      reset();
+    }
+    setCreateOpen(open);
   };
 
   const formatDate = (iso: string) => {
@@ -210,13 +241,14 @@ export default function DashboardPage() {
       )}
 
       {/* Create Design Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent className="sm:max-w-md">
+      <Dialog open={createOpen} onOpenChange={handleDialogClose}>
+        <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>New Design</DialogTitle>
           </DialogHeader>
           <form onSubmit={handleSubmit(onSubmit)}>
-            <div className="flex flex-col gap-4 py-2">
+            <div className="flex flex-col gap-5 py-2">
+              {/* Name + description */}
               <div className="flex flex-col gap-1.5">
                 <Label htmlFor="name">Name</Label>
                 <Input
@@ -234,16 +266,51 @@ export default function DashboardPage() {
                 <Textarea
                   id="description"
                   placeholder="Optional description…"
-                  rows={3}
+                  rows={2}
                   {...register('description')}
                 />
               </div>
+
+              {/* Template picker */}
+              <div className="flex flex-col gap-2">
+                <Label>Start from template</Label>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  {DESIGN_TEMPLATES.map((template) => {
+                    const isSelected = selectedTemplateId === template.id;
+                    return (
+                      <button
+                        key={template.id}
+                        type="button"
+                        onClick={() => setSelectedTemplateId(template.id)}
+                        aria-pressed={isSelected}
+                        className={cn(
+                          'relative flex flex-col gap-1 rounded-lg border p-3 text-left transition-colors',
+                          isSelected
+                            ? 'border-primary bg-primary/5 text-foreground'
+                            : 'border-border bg-card hover:bg-muted/50',
+                        )}
+                      >
+                        {isSelected && (
+                          <span className="absolute right-2 top-2 flex size-4 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                            <Check className="size-2.5" />
+                          </span>
+                        )}
+                        <span className="text-sm font-medium">{template.name}</span>
+                        <span className="text-xs text-muted-foreground leading-snug">
+                          {template.description}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
             </div>
-            <DialogFooter className="mt-2">
+
+            <DialogFooter className="mt-4">
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => setCreateOpen(false)}
+                onClick={() => handleDialogClose(false)}
               >
                 Cancel
               </Button>
@@ -254,6 +321,24 @@ export default function DashboardPage() {
           </form>
         </DialogContent>
       </Dialog>
+
+      {/* Scaffold partial-failure toast */}
+      {scaffoldToast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-lg border border-border bg-background px-4 py-3 shadow-lg text-sm max-w-sm"
+        >
+          <span className="text-muted-foreground">{scaffoldToast}</span>
+          <button
+            onClick={() => setScaffoldToast(null)}
+            className="ml-2 shrink-0 text-muted-foreground hover:text-foreground"
+            aria-label="Dismiss notification"
+          >
+            ×
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/dashboard/designTemplates.test.ts
+++ b/frontend/src/features/dashboard/designTemplates.test.ts
@@ -1,0 +1,261 @@
+/// <reference types="vitest/globals" />
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DESIGN_TEMPLATES } from './designTemplates';
+
+// ── Mock API modules ─────────────────────────────────────────────────────────
+
+const mockSiteCreate = vi.fn();
+const mockSuperblockCreate = vi.fn();
+const mockBlockCreate = vi.fn();
+
+vi.mock('@/api/sites', () => ({
+  sitesApi: {
+    create: (...args: unknown[]) => mockSiteCreate(...args),
+  },
+}));
+
+vi.mock('@/api/superblocks', () => ({
+  superblocksApi: {
+    create: (...args: unknown[]) => mockSuperblockCreate(...args),
+  },
+}));
+
+vi.mock('@/api/blocks', () => ({
+  blocksApi: {
+    create: (...args: unknown[]) => mockBlockCreate(...args),
+  },
+  scaffoldApi: {},
+  superBlocksApi: {},
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function getTemplate(id: string) {
+  const t = DESIGN_TEMPLATES.find((t) => t.id === id);
+  if (!t) throw new Error(`Template "${id}" not found`);
+  return t;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Template list ────────────────────────────────────────────────────────────
+
+describe('DESIGN_TEMPLATES', () => {
+  it('exports exactly 4 templates', () => {
+    expect(DESIGN_TEMPLATES).toHaveLength(4);
+  });
+
+  it('includes blank, 2-stage-clos, 3-stage-clos, and pod-based', () => {
+    const ids = DESIGN_TEMPLATES.map((t) => t.id);
+    expect(ids).toContain('blank');
+    expect(ids).toContain('2-stage-clos');
+    expect(ids).toContain('3-stage-clos');
+    expect(ids).toContain('pod-based');
+  });
+
+  it('blank is the first entry (default)', () => {
+    expect(DESIGN_TEMPLATES[0].id).toBe('blank');
+  });
+
+  it('every template has id, name, description, and scaffold function', () => {
+    for (const t of DESIGN_TEMPLATES) {
+      expect(typeof t.id).toBe('string');
+      expect(typeof t.name).toBe('string');
+      expect(typeof t.description).toBe('string');
+      expect(typeof t.scaffold).toBe('function');
+    }
+  });
+});
+
+// ── blank ────────────────────────────────────────────────────────────────────
+
+describe('blank template', () => {
+  it('scaffold makes no API calls', async () => {
+    await getTemplate('blank').scaffold(1);
+    expect(mockSiteCreate).not.toHaveBeenCalled();
+    expect(mockSuperblockCreate).not.toHaveBeenCalled();
+    expect(mockBlockCreate).not.toHaveBeenCalled();
+  });
+
+  it('scaffold resolves without error', async () => {
+    await expect(getTemplate('blank').scaffold(42)).resolves.toBeUndefined();
+  });
+});
+
+// ── 2-stage Clos ─────────────────────────────────────────────────────────────
+
+describe('2-stage Clos template', () => {
+  beforeEach(() => {
+    mockSiteCreate.mockResolvedValue({ id: 10, name: 'Site 1' });
+    mockSuperblockCreate.mockResolvedValue({ id: 20, name: 'Pod A' });
+    mockBlockCreate.mockResolvedValue({ block: { id: 30, name: 'Block 1' } });
+  });
+
+  it('creates 1 site, 1 superblock, 1 block on success path', async () => {
+    await getTemplate('2-stage-clos').scaffold(1);
+    expect(mockSiteCreate).toHaveBeenCalledTimes(1);
+    expect(mockSuperblockCreate).toHaveBeenCalledTimes(1);
+    expect(mockBlockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates site named "Site 1"', async () => {
+    await getTemplate('2-stage-clos').scaffold(1);
+    expect(mockSiteCreate).toHaveBeenCalledWith(1, expect.objectContaining({ name: 'Site 1' }));
+  });
+
+  it('creates superblock named "Pod A" under the site', async () => {
+    await getTemplate('2-stage-clos').scaffold(1);
+    expect(mockSuperblockCreate).toHaveBeenCalledWith(10, expect.objectContaining({ name: 'Pod A' }));
+  });
+
+  it('creates block named "Block 1" under the superblock', async () => {
+    await getTemplate('2-stage-clos').scaffold(1);
+    expect(mockBlockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ super_block_id: 20, name: 'Block 1' }),
+    );
+  });
+
+  it('does not pre-assign leaf_model_id or spine_model_id', async () => {
+    await getTemplate('2-stage-clos').scaffold(1);
+    const call = mockBlockCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.leaf_model_id).toBeUndefined();
+    expect(call.spine_model_id).toBeUndefined();
+  });
+
+  it('throws when site creation fails (partial failure path)', async () => {
+    mockSiteCreate.mockRejectedValue(new Error('network error'));
+    await expect(getTemplate('2-stage-clos').scaffold(1)).rejects.toThrow('network error');
+  });
+
+  it('throws when superblock creation fails (partial failure path)', async () => {
+    mockSuperblockCreate.mockRejectedValue(new Error('superblock error'));
+    await expect(getTemplate('2-stage-clos').scaffold(1)).rejects.toThrow('superblock error');
+    expect(mockBlockCreate).not.toHaveBeenCalled();
+  });
+
+  it('throws when block creation fails (partial failure path)', async () => {
+    mockBlockCreate.mockRejectedValue(new Error('block error'));
+    await expect(getTemplate('2-stage-clos').scaffold(1)).rejects.toThrow('block error');
+  });
+});
+
+// ── 3-stage Clos ─────────────────────────────────────────────────────────────
+
+describe('3-stage Clos template', () => {
+  beforeEach(() => {
+    mockSiteCreate.mockResolvedValue({ id: 11, name: 'Site 1' });
+    mockSuperblockCreate.mockResolvedValue({ id: 21, name: 'Pod A' });
+    mockBlockCreate.mockResolvedValue({ block: { id: 31, name: 'Block 1' } });
+  });
+
+  it('creates 1 site, 1 superblock, 1 block on success path', async () => {
+    await getTemplate('3-stage-clos').scaffold(2);
+    expect(mockSiteCreate).toHaveBeenCalledTimes(1);
+    expect(mockSuperblockCreate).toHaveBeenCalledTimes(1);
+    expect(mockBlockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates site named "Site 1"', async () => {
+    await getTemplate('3-stage-clos').scaffold(2);
+    expect(mockSiteCreate).toHaveBeenCalledWith(2, expect.objectContaining({ name: 'Site 1' }));
+  });
+
+  it('creates superblock named "Pod A"', async () => {
+    await getTemplate('3-stage-clos').scaffold(2);
+    expect(mockSuperblockCreate).toHaveBeenCalledWith(11, expect.objectContaining({ name: 'Pod A' }));
+  });
+
+  it('does not pre-assign devices', async () => {
+    await getTemplate('3-stage-clos').scaffold(2);
+    const call = mockBlockCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.leaf_model_id).toBeUndefined();
+    expect(call.spine_model_id).toBeUndefined();
+  });
+
+  it('throws on partial failure', async () => {
+    mockSiteCreate.mockRejectedValue(new Error('site error'));
+    await expect(getTemplate('3-stage-clos').scaffold(2)).rejects.toThrow('site error');
+    expect(mockSuperblockCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ── Pod-based fabric ──────────────────────────────────────────────────────────
+
+describe('pod-based fabric template', () => {
+  beforeEach(() => {
+    mockSiteCreate.mockResolvedValue({ id: 12, name: 'Site 1' });
+    mockSuperblockCreate
+      .mockResolvedValueOnce({ id: 22, name: 'Pod A' })
+      .mockResolvedValueOnce({ id: 23, name: 'Pod B' });
+    mockBlockCreate
+      .mockResolvedValueOnce({ block: { id: 40, name: 'Block 1' } })
+      .mockResolvedValueOnce({ block: { id: 41, name: 'Block 2' } })
+      .mockResolvedValueOnce({ block: { id: 42, name: 'Block 3' } })
+      .mockResolvedValueOnce({ block: { id: 43, name: 'Block 4' } });
+  });
+
+  it('creates 1 site, 2 superblocks, 4 blocks on success path', async () => {
+    await getTemplate('pod-based').scaffold(3);
+    expect(mockSiteCreate).toHaveBeenCalledTimes(1);
+    expect(mockSuperblockCreate).toHaveBeenCalledTimes(2);
+    expect(mockBlockCreate).toHaveBeenCalledTimes(4);
+  });
+
+  it('creates site named "Site 1"', async () => {
+    await getTemplate('pod-based').scaffold(3);
+    expect(mockSiteCreate).toHaveBeenCalledWith(3, expect.objectContaining({ name: 'Site 1' }));
+  });
+
+  it('creates superblocks named "Pod A" and "Pod B"', async () => {
+    await getTemplate('pod-based').scaffold(3);
+    expect(mockSuperblockCreate).toHaveBeenCalledWith(12, expect.objectContaining({ name: 'Pod A' }));
+    expect(mockSuperblockCreate).toHaveBeenCalledWith(12, expect.objectContaining({ name: 'Pod B' }));
+  });
+
+  it('creates 2 blocks under Pod A and 2 under Pod B', async () => {
+    await getTemplate('pod-based').scaffold(3);
+    const calls = mockBlockCreate.mock.calls as Array<[Record<string, unknown>, ...unknown[]]>;
+    const podACalls = calls.filter((c) => c[0].super_block_id === 22);
+    const podBCalls = calls.filter((c) => c[0].super_block_id === 23);
+    expect(podACalls).toHaveLength(2);
+    expect(podBCalls).toHaveLength(2);
+  });
+
+  it('uses named blocks (Block 1–4), not generic names', async () => {
+    await getTemplate('pod-based').scaffold(3);
+    const calls = mockBlockCreate.mock.calls as Array<[Record<string, unknown>, ...unknown[]]>;
+    const names = calls.map((c) => c[0].name);
+    expect(names).toEqual(['Block 1', 'Block 2', 'Block 3', 'Block 4']);
+  });
+
+  it('does not pre-assign devices on any block', async () => {
+    await getTemplate('pod-based').scaffold(3);
+    const calls = mockBlockCreate.mock.calls as Array<[Record<string, unknown>, ...unknown[]]>;
+    for (const call of calls) {
+      expect(call[0].leaf_model_id).toBeUndefined();
+      expect(call[0].spine_model_id).toBeUndefined();
+    }
+  });
+
+  it('throws on partial failure (site error)', async () => {
+    mockSiteCreate.mockRejectedValue(new Error('network error'));
+    await expect(getTemplate('pod-based').scaffold(3)).rejects.toThrow('network error');
+    expect(mockSuperblockCreate).not.toHaveBeenCalled();
+    expect(mockBlockCreate).not.toHaveBeenCalled();
+  });
+
+  it('throws on partial failure (second superblock error)', async () => {
+    // Reset implementations so that the beforeEach queue is replaced
+    mockSuperblockCreate.mockReset();
+    mockBlockCreate.mockReset();
+    mockSuperblockCreate
+      .mockResolvedValueOnce({ id: 22, name: 'Pod A' })
+      .mockRejectedValueOnce(new Error('pod B error'));
+    mockBlockCreate
+      .mockResolvedValueOnce({ block: { id: 40, name: 'Block 1' } })
+      .mockResolvedValueOnce({ block: { id: 41, name: 'Block 2' } });
+    await expect(getTemplate('pod-based').scaffold(3)).rejects.toThrow('pod B error');
+  });
+});

--- a/frontend/src/features/dashboard/designTemplates.ts
+++ b/frontend/src/features/dashboard/designTemplates.ts
@@ -1,0 +1,88 @@
+import { sitesApi } from '@/api/sites';
+import { superblocksApi } from '@/api/superblocks';
+import { blocksApi } from '@/api/blocks';
+
+export interface DesignTemplate {
+  id: string;
+  name: string;
+  description: string;
+  /** Returns void on success. Throws on unrecoverable error. */
+  scaffold: (designId: number) => Promise<void>;
+}
+
+/**
+ * Blank template — no hierarchy is created.
+ * This is the default / current behaviour.
+ */
+const blankTemplate: DesignTemplate = {
+  id: 'blank',
+  name: 'Blank',
+  description: 'Start with an empty canvas. Add sites, pods, and blocks manually.',
+  scaffold: async (_designId: number) => {
+    // no-op
+  },
+};
+
+/**
+ * 2-stage Clos — 1 site → 1 superblock → 1 block.
+ * Each block is an independent leaf–spine fabric.
+ */
+const twoStageClos: DesignTemplate = {
+  id: '2-stage-clos',
+  name: '2-stage Clos',
+  description: 'Single pod with one leaf–spine block. The simplest production-grade Clos fabric.',
+  scaffold: async (designId: number) => {
+    const site = await sitesApi.create(designId, { name: 'Site 1' });
+    const superblock = await superblocksApi.create(site.id, { name: 'Pod A' });
+    await blocksApi.create({ super_block_id: superblock.id, name: 'Block 1' });
+  },
+};
+
+/**
+ * 3-stage Clos — 1 site → 1 superblock → 1 block, sized for a super-spine tier.
+ * Structurally identical to 2-stage at creation time; the "3-stage" designation
+ * signals that super-spine aggregation will be assigned at the superblock level.
+ */
+const threeStageClos: DesignTemplate = {
+  id: '3-stage-clos',
+  name: '3-stage Clos',
+  description:
+    'Single pod with one block and a super-spine tier. Scales beyond a single leaf–spine plane.',
+  scaffold: async (designId: number) => {
+    const site = await sitesApi.create(designId, { name: 'Site 1' });
+    const superblock = await superblocksApi.create(site.id, {
+      name: 'Pod A',
+      description: 'Super-spine aggregation pod',
+    });
+    await blocksApi.create({ super_block_id: superblock.id, name: 'Block 1' });
+  },
+};
+
+/**
+ * Pod-based fabric — 1 site → 2 superblocks → 2 blocks each (4 blocks total).
+ * Models a multi-pod datacenter with isolated failure domains.
+ */
+const podBasedFabric: DesignTemplate = {
+  id: 'pod-based',
+  name: 'Pod-based fabric',
+  description:
+    'Two independent pods, each with two leaf–spine blocks. Ideal for large-scale multi-pod DCs.',
+  scaffold: async (designId: number) => {
+    const site = await sitesApi.create(designId, { name: 'Site 1' });
+
+    const podA = await superblocksApi.create(site.id, { name: 'Pod A' });
+    await blocksApi.create({ super_block_id: podA.id, name: 'Block 1' });
+    await blocksApi.create({ super_block_id: podA.id, name: 'Block 2' });
+
+    const podB = await superblocksApi.create(site.id, { name: 'Pod B' });
+    await blocksApi.create({ super_block_id: podB.id, name: 'Block 3' });
+    await blocksApi.create({ super_block_id: podB.id, name: 'Block 4' });
+  },
+};
+
+export const DESIGN_TEMPLATES: DesignTemplate[] = [
+  blankTemplate,
+  twoStageClos,
+  threeStageClos,
+  podBasedFabric,
+];

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -8,6 +8,7 @@ export default mergeConfig(
       environment: 'happy-dom',
       globals: true,
       setupFiles: ['./src/test/setup.ts'],
+      exclude: ['**/node_modules/**', '**/e2e/**'],
     },
   })
 )


### PR DESCRIPTION
## Summary

- Adds a "Start from template" section (visible by default) to the New Design dialog with 4 options: **Blank**, **2-stage Clos**, **3-stage Clos**, and **Pod-based fabric**
- Templates are defined in `designTemplates.ts` — adding a new template is a single-entry change
- Non-blank templates scaffold named hierarchy (Site 1 / Pod A / Block N) using existing `sitesApi`, `superblocksApi`, and `blocksApi` — no `scaffoldApi.get()` and no device pre-assignment
- Scaffold runs in the `onSuccess` callback of the design create mutation; on partial failure a non-blocking toast is shown and the user lands on the design view with whatever was created
- Adds knowledge base article `docs/knowledge/dashboard.md` documenting each template

## Acceptance Criteria

- [x] New Design dialog has "Start from template" section visible on open (not collapsed)
- [x] Shows 4 options: Blank (default), 2-stage Clos, 3-stage Clos, Pod-based fabric
- [x] Selecting Blank preserves today's 2-click create behavior — no scaffold calls
- [x] Non-blank template: creates design, runs scaffold, navigates to `/design` on success
- [x] Templates create named hierarchy ("Site 1", "Pod A", "Block 1") not generic names
- [x] No device pre-assignment
- [x] On scaffold failure: non-blocking toast + land on design view with partial progress
- [x] Templates defined in `designTemplates.ts` — adding a new template is one-entry change
- [x] Unit tests for each template's scaffold function (success path, partial failure path) with mocked API — `designTemplates.test.ts` (27 tests)
- [x] Component tests: template options visible on open, Blank skips scaffold, non-blank invokes it — `DashboardPage.test.tsx` (10 tests)
- [x] Playwright e2e: `frontend/e2e/design-templates.spec.ts` — requires running backend, excluded from vitest
- [x] Docs: `docs/knowledge/dashboard.md` describing each template

## Test plan

- [x] `make test` passes (230 tests, 20 test files)
- [x] `make build` succeeds
- [ ] Manual: open dialog → verify 4 template cards appear with Blank selected
- [ ] Manual: create with 2-stage Clos → confirm Site 1 / Pod A / Block 1 in hierarchy
- [ ] Manual: create with Pod-based → confirm 2 pods × 2 blocks = 4 blocks
- [ ] Manual: simulate API error during scaffold → confirm toast + design view loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)